### PR TITLE
Hex file refs update

### DIFF
--- a/python/pc_ble_driver_py/__init__.py
+++ b/python/pc_ble_driver_py/__init__.py
@@ -39,4 +39,4 @@ Package marker file.
 
 """
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/python/pc_ble_driver_py/config.py
+++ b/python/pc_ble_driver_py/config.py
@@ -64,10 +64,10 @@ def conn_ic_hex_get():
     if __conn_ic_id__.upper() == "NRF51":
         return os.path.join(os.path.dirname(__file__),
                         'hex', 'sd_api_v2',
-                        'connectivity_1.0.1_115k2_with_s130_2.0.1.hex')
+                        'connectivity_1.1.0_115k2_with_s130_2.0.1.hex')
     elif __conn_ic_id__.upper() == "NRF52":
         return os.path.join(os.path.dirname(__file__),
                         'hex', 'sd_api_v3',
-                        'connectivity_1.0.1_115k2_with_s132_3.0.hex')
+                        'connectivity_1.1.0_115k2_with_s132_3.0.hex')
     else:
         raise RuntimeError('Invalid connectivity IC identifier: {}.'.format(__conn_ic_id__))


### PR DESCRIPTION
Since the hex files in pc-ble-driver submodule have been updated to newer versions, it is necessary to update the reference to those files.

The update of pc-ble-driver submodule reference was required to pull in the latest bugfixes.