### PR TITLE
BLE Adapter: support enabling notifications on CCCD

### DIFF
--- a/python/pc_ble_driver_py/ble_adapter.py
+++ b/python/pc_ble_driver_py/ble_adapter.py
@@ -223,6 +223,23 @@ class BLEAdapter(BLEDriverObserver):
                                                         ch.end_handle)
         return BLEGattStatusCode.success
 
+    @NordicSemiErrorCheck(expected = BLEGattStatusCode.success)
+    def enable_indication(self, conn_handle, uuid):
+        cccd_list = [2, 0]
+
+        handle = self.db_conns[conn_handle].get_cccd_handle(uuid)
+        if handle == None:
+            raise NordicSemiException('CCCD not found')
+
+        write_params = BLEGattcWriteParams(BLEGattWriteOperation.write_req,
+                                           BLEGattExecWriteFlag.unused,
+                                           handle,
+                                           cccd_list,
+                                           0)
+
+        self.driver.ble_gattc_write(conn_handle, write_params)
+        result = self.evt_sync[conn_handle].wait(evt = BLEEvtID.gattc_evt_write_rsp)
+        return result['status']
 
     @NordicSemiErrorCheck(expected = BLEGattStatusCode.success)
     def enable_notification(self, conn_handle, uuid):


### PR DESCRIPTION
This is needed for the buttonless DFU CCCD