### PR TITLE
Fixing SWIG BLE event memory allocation for nRF51.

### DIFF
--- a/swig/pc_ble_driver.i.in
+++ b/swig/pc_ble_driver.i.in
@@ -150,8 +150,16 @@ static void PythonEvtCallBack(adapter_t *adapter, ble_evt_t *ble_event)
     // Do a copy of the event so that the Python developer is able to access the event after
     // this callback is complete. The event that is received in this function is allocated
     // on the stack of the function calling this function.
+
+#if _pc_ble_driver_sd_api_v2_EXPORTS
+    copied_ble_event = (ble_evt_t*)malloc(sizeof(ble_evt_t));
+    memcpy(copied_ble_event, ble_event, sizeof(ble_evt_t));
+#endif
+
+#if _pc_ble_driver_sd_api_v3_EXPORTS
     copied_ble_event = (ble_evt_t*)malloc(ble_event->header.evt_len);
     memcpy(copied_ble_event, ble_event, ble_event->header.evt_len);
+#endif
 
     // Handling of Python Global Interpretor Lock (GIL)
     gstate = PyGILState_Ensure();


### PR DESCRIPTION
Apparently sd_api_v2 in some cases doesn't set `ble_event->header.evt_len` correctly, so complete event needs to be copied, however that doesn't work for sd_api_v3 due to long MTU was introduced and packets can be bigger than the size of the struct, hence different malloc.