### PR TITLE
Check for firmware version and baud rate in Flasher

### DIFF
--- a/python/pc_ble_driver_py/ble_driver.py
+++ b/python/pc_ble_driver_py/ble_driver.py
@@ -890,7 +890,7 @@ class Flasher(object):
         result = list()
         for line in data.splitlines():
             line = re.sub(r"(^.*:)|(\|.*$)", '', line)
-            result.extend([i for i in line.split()])
+            result.extend(line.split())
         return result
 
     def reset(self):

--- a/python/pc_ble_driver_py/ble_driver.py
+++ b/python/pc_ble_driver_py/ble_driver.py
@@ -845,6 +845,10 @@ class Flasher(object):
         return None
 
     NRFJPROG = 'nrfjprog'
+    FW_STRUCT_ADDRESS = 0x20000
+    FW_STRUCT_LENGTH = 24
+    FW_MAGIC_NUMBER = ['17', 'A5', 'D8', '46']
+
     def __init__(self, serial_port = None, snr = None):
         if serial_port is None and snr is None:
             raise NordicSemiException('Invalid Flasher initialization')
@@ -869,39 +873,37 @@ class Flasher(object):
         self.family = config.__conn_ic_id__
 
     def fw_check(self):
-        data    = self.read(addr = 0x20000, size = 4)
-        return data == [0x17, 0xA5, 0xD8, 0x46] # hex magic number
+        fw_struct = self.read_fw_struct()
+        return (len(fw_struct) == Flasher.FW_STRUCT_LENGTH and
+                Flasher.is_valid_magic_number(fw_struct) and
+                Flasher.is_valid_version(fw_struct) and
+                Flasher.is_valid_baud_rate(fw_struct))
 
     def fw_flash(self):
         self.erase()
         hex_file = config.conn_ic_hex_get()
         self.program(hex_file)
 
-    def read(self, addr, size):
-        args = ['--memrd', str(addr), '--w', '8', '--n', str(size)]
+    def read_fw_struct(self):
+        args = ['--memrd', str(Flasher.FW_STRUCT_ADDRESS), '--w', '8', '--n', str(Flasher.FW_STRUCT_LENGTH)]
         data = self.call_cmd(args)
-
         result = list()
         for line in data.splitlines():
             line = re.sub(r"(^.*:)|(\|.*$)", '', line)
-            result.extend([int(i, 16) for i in line.split()])
+            result.extend([i for i in line.split()])
         return result
-
 
     def reset(self):
         args    = ['--reset']
         self.call_cmd(args)
 
-
     def erase(self):
         args    = ['--eraseall']
         self.call_cmd(args)
 
-
     def program(self, path):
         args    = ['--program', path]
         self.call_cmd(args)
-
 
     @wrapt.synchronized(api_lock)
     def call_cmd(self, args):
@@ -914,6 +916,23 @@ class Flasher(object):
             else: 
                 raise
 
+    @staticmethod
+    def is_valid_magic_number(fw_struct):
+        magic_number = fw_struct[:4]
+        return magic_number == Flasher.FW_MAGIC_NUMBER
+
+    @staticmethod
+    def is_valid_version(fw_struct):
+        major = int(fw_struct[12], 16)
+        minor = int(fw_struct[13], 16)
+        patch = int(fw_struct[14], 16)
+        version = '.'.join(map(str, [major, minor, patch]))
+        return config.get_connectivity_hex_version() == version
+
+    @staticmethod
+    def is_valid_baud_rate(fw_struct):
+        baud_rate = int(''.join(fw_struct[20:24][::-1]), 16)
+        return config.get_connectivity_hex_baud_rate() == baud_rate
 
 
 class BLEDriver(object):

--- a/python/pc_ble_driver_py/config.py
+++ b/python/pc_ble_driver_py/config.py
@@ -43,6 +43,7 @@
 # * "NRF52"
 __conn_ic_id__ = None
 
+
 def sd_api_ver_get():
     if __conn_ic_id__ is None:
         raise RuntimeError('Connectivity IC identifier __conn_ic_id__ is not set')
@@ -71,3 +72,11 @@ def conn_ic_hex_get():
                         'connectivity_1.2.0_115k2_with_s132_3.0.hex')
     else:
         raise RuntimeError('Invalid connectivity IC identifier: {}.'.format(__conn_ic_id__))
+
+
+def get_connectivity_hex_version():
+    return '1.2.0'
+
+
+def get_connectivity_hex_baud_rate():
+    return 115200

--- a/python/pc_ble_driver_py/test/ble_driver_test.py
+++ b/python/pc_ble_driver_py/test/ble_driver_test.py
@@ -1,0 +1,73 @@
+import unittest
+from pc_ble_driver_py import config
+config.__conn_ic_id__ = 'NRF52'
+from pc_ble_driver_py.ble_driver import Flasher
+
+
+class FlasherMagicNumberTestCase(unittest.TestCase):
+
+    def test_invalid_number(self):
+        self.assertEqual(Flasher.is_valid_magic_number(
+            ['17', 'A5', 'D8', '45']
+        ), False)
+
+    def test_valid_number(self):
+        self.assertEqual(Flasher.is_valid_magic_number(
+            ['17', 'A5', 'D8', '46']
+        ), True)
+
+
+class FlasherVersionTestCase(unittest.TestCase):
+
+    def test_invalid_version(self):
+        self.assertEqual(Flasher.is_valid_version(
+            ['17', 'A5', 'D8', '46',  # magic number
+             '02',                    # struct version
+             'FF', 'FF', 'FF',        # (reserved for future use)
+             '00', '00', '00', '00',  # revision hash
+             '01', '01', '00'         # major, minor, patch
+             ]), False)
+
+    def test_valid_version(self):
+        self.assertEqual(Flasher.is_valid_version(
+            ['17', 'A5', 'D8', '46',  # magic number
+             '02',                    # struct version
+             'FF', 'FF', 'FF',        # (reserved for future use)
+             '00', '00', '00', '00',  # revision hash
+             '01', '02', '00'         # major, minor, patch
+            ]), True)
+
+
+class FlasherBaudRateTestCase(unittest.TestCase):
+
+    def test_invalid_baud_rate(self):
+        self.assertEqual(Flasher.is_valid_baud_rate(
+            ['17', 'A5', 'D8', '46',  # magic number
+             '02',                    # struct version
+             'FF', 'FF', 'FF',        # (reserved for future use)
+             '00', '00', '00', '00',  # revision hash
+             '01', '02', '00',        # major, minor, patch
+             'FF',                    # (reserved for future use)
+             '03',                    # softdevice ble api number
+             '01',                    # transport type
+             'FF', 'FF',              # (reserved for future use)
+             '00', 'C2', '02', '00'   # baud rate
+             ]), False)
+
+    def test_valid_baud_rate(self):
+        self.assertEqual(Flasher.is_valid_baud_rate(
+            ['17', 'A5', 'D8', '46',  # magic number
+             '02',                    # struct version
+             'FF', 'FF', 'FF',        # (reserved for future use)
+             '00', '00', '00', '00',  # revision hash
+             '01', '02', '00',        # major, minor, patch
+             'FF',                    # (reserved for future use)
+             '03',                    # softdevice ble api number
+             '01',                    # transport type
+             'FF', 'FF',              # (reserved for future use)
+             '00', 'C2', '01', '00'   # baud rate
+             ]), True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When passing `auto_flash=True` to BLEDriver, it checks if a connectivity firmware is present, and flashes the board if it is not. All connectivity firmwares have meta information written to address 0x20000. This starts with a "magic number" which is followed by version information, baud rate, etc.

The Flasher only looked for the magic number when checking for a connectivity firmware. There are multiple connectivity firmwares with different versions and baud rates, and pc-ble-driver-py is currently configured to use connectivity v1.2.0 with baud rate 115200. Now also looking at the connectivity version and baud rate to determine if we need to flash or not.