### PR TITLE
Fix union type

### DIFF
--- a/pc_ble_driver_py/ble_adapter.py
+++ b/pc_ble_driver_py/ble_adapter.py
@@ -550,9 +550,6 @@ class BLEAdapter(BLEDriverObserver):
     def on_gap_evt_data_length_update_request(self, ble_driver, conn_handle, data_length_params):
         self.driver.ble_gap_data_length_update(conn_handle, None, None)
 
-    def on_gatts_evt_exchange_mtu_request(self, ble_driver, conn_handle, client_mtu):
-        self.driver.ble_gatts_exchange_mtu_reply(conn_handle, self.default_mtu)
-
     def on_att_mtu_exchanged(self, ble_driver, conn_handle, att_mtu):
         self.db_conns[conn_handle].att_mtu = att_mtu
 

--- a/pc_ble_driver_py/ble_adapter.py
+++ b/pc_ble_driver_py/ble_adapter.py
@@ -550,6 +550,9 @@ class BLEAdapter(BLEDriverObserver):
     def on_gap_evt_data_length_update_request(self, ble_driver, conn_handle, data_length_params):
         self.driver.ble_gap_data_length_update(conn_handle, None, None)
 
+    def on_gatts_evt_exchange_mtu_request(self, ble_driver, conn_handle, client_mtu):
+        ble_driver.ble_gatts_exchange_mtu_reply(conn_handle, self.default_mtu)
+
     def on_att_mtu_exchanged(self, ble_driver, conn_handle, att_mtu):
         self.db_conns[conn_handle].att_mtu = att_mtu
 

--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -1117,25 +1117,32 @@ class BLEConfigCommon(BLEConfigBase):
         return ble_cfg
 
 
-class BLEConfigGap(BLEConfigBase):
+class BLEConfigGapRoleCount(BLEConfigBase):
     def __init__(self,
                  central_role_count=1,
                  periph_role_count=1,
-                 central_sec_count=1,
-                 device_name="nRF5x-py",
-                 device_name_read_only=True):
+                 central_sec_count=1):
         self.central_role_count = central_role_count
         self.periph_role_count = periph_role_count
         self.central_sec_count = central_sec_count
-        self.device_name = device_name
-        self.device_name_read_only = device_name_read_only
-        self.__device_name = None
 
     def to_c(self):
         ble_cfg = driver.ble_cfg_t()
         ble_cfg.gap_cfg.role_count_cfg.periph_role_count = self.periph_role_count
         ble_cfg.gap_cfg.role_count_cfg.central_role_count = self.central_role_count
         ble_cfg.gap_cfg.role_count_cfg.central_sec_count = self.central_sec_count
+        return ble_cfg
+
+class BLEConfigGapDeviceName(BLEConfigBase):
+    def __init__(self,
+                 device_name="nRF5x-py",
+                 device_name_read_only=True):
+        self.device_name = device_name
+        self.device_name_read_only = device_name_read_only
+        self.__device_name = None
+
+    def to_c(self):
+        ble_cfg = driver.ble_cfg_t()
         if self.device_name_read_only:
             ble_cfg.gap_cfg.device_name_cfg.write_perm.sm = 0
             ble_cfg.gap_cfg.device_name_cfg.write_perm.lv = 0

--- a/pc_ble_driver_py/examples/heart_rate_collector.py
+++ b/pc_ble_driver_py/examples/heart_rate_collector.py
@@ -42,19 +42,20 @@ from pc_ble_driver_py.observers import *
 
 TARGET_DEV_NAME = "Nordic_HRM"
 CONNECTIONS = 1
+CFG_TAG = 1
 
 
 def init(conn_ic_id):
     # noinspection PyGlobalUndefined
     global config, BLEDriver, BLEAdvData, BLEEvtID, BLEAdapter,\
         BLEEnableParams, BLEGapTimeoutSrc, BLEUUID, BLEConfigCommon, BLEConfig, BLEConfigConnGatt, \
-        BLEConfigGapRoleCount, BLEConfigGapDeviceName, BLEConfigConnGatt
+        BLEConfigGapRoleCount, BLEConfigGapDeviceName
     from pc_ble_driver_py import config
     config.__conn_ic_id__ = conn_ic_id
     # noinspection PyUnresolvedReferences
     from pc_ble_driver_py.ble_driver import BLEDriver, BLEAdvData,\
         BLEEvtID, BLEEnableParams, BLEGapTimeoutSrc, BLEUUID, BLEConfigCommon, BLEConfig, BLEConfigConnGatt, \
-        BLEConfigGapRoleCount, BLEConfigGapDeviceName, BLEConfigConnGatt
+        BLEConfigGapRoleCount, BLEConfigGapDeviceName
     # noinspection PyUnresolvedReferences
     from pc_ble_driver_py.ble_adapter import BLEAdapter
     global nrf_sd_ble_api_ver
@@ -82,11 +83,12 @@ class HRCollector(BLEDriverObserver, BLEAdapterObserver):
             gap_cfg.periph_role_count = 1
             gap_cfg.central_role_count = 1
             gap_cfg.central_sec_count = 0
+            gap_cfg.tag = CFG_TAG
             self.adapter.driver.ble_cfg_set(BLEConfig.role_count, gap_cfg)
 
             gatt_cfg = BLEConfigConnGatt()
-            gatt_cfg.att_mtu = 273
-            gatt_cfg.tag = 1
+            gatt_cfg.att_mtu = 250
+            gatt_cfg.tag = CFG_TAG
             self.adapter.driver.ble_cfg_set(BLEConfig.conn_gatt, gatt_cfg)
 
             self.adapter.driver.ble_enable()
@@ -131,7 +133,7 @@ class HRCollector(BLEDriverObserver, BLEAdapterObserver):
                                                                                     dev_name))
 
         if dev_name == TARGET_DEV_NAME:
-            self.adapter.connect(peer_addr, tag=1)
+            self.adapter.connect(peer_addr, tag=CFG_TAG)
 
     def on_notification(self, ble_adapter, conn_handle, uuid, data):
         if len(data) > 32:


### PR DESCRIPTION
This PR is due to fixing MTU not configuring correctly. The base cause of the issue is that in pc-ble-driver `ble_gap_cfg` is type of union which makes it fail when setting `role_count_cfg` and `device_name_cfg`.