### PR TITLE
Load swig provided module, not ctypes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,11 @@ foreach(SD_API_VER ${SD_API_VERS})
         RESOURCE DESTINATION "${BUILD_OUTPUT_HEX_DIR}/sd_api_v${SD_API_VER}"
     )
 
+    install(
+        FILES ${PC_BLE_DRIVER_PY_OUTDIR}/nrf_ble_driver_sd_api_v${SD_API_VER}.py
+        DESTINATION ${BUILD_OUTPUT_LIB_DIR}
+    )
+
     if(NRF_BLE_DRIVER_LINKAGE_TYPE STREQUAL "shared")
         install(
             FILES $<TARGET_FILE:nrf::nrf_ble_driver_sd_api_v${SD_API_VER}_${NRF_BLE_DRIVER_LINKAGE_TYPE}>

--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -62,30 +62,20 @@ import pc_ble_driver_py.config as config
 
 nrf_sd_ble_api_ver = config.sd_api_ver_get()
 # Load pc_ble_driver
-SWIG_MODULE_NAME = "_nrf_ble_driver_sd_api_v{}".format(nrf_sd_ble_api_ver)
 
-if getattr(sys, 'frozen', False):
-    # we are running in a bundle
-    this_dir = sys._MEIPASS
+ATT_MTU_DEFAULT = None
+
+if nrf_sd_ble_api_ver == 2:
+    import pc_ble_driver_py.lib.nrf_ble_driver_sd_api_v2 as driver
+    ATT_MTU_DEFAULT = driver.GATT_MTU_SIZE_DEFAULT
+elif nrf_sd_ble_api_ver == 5:
+    import pc_ble_driver_py.lib.nrf_ble_driver_sd_api_v5 as driver
+    ATT_MTU_DEFAULT = driver.BLE_GATT_ATT_MTU_DEFAULT
 else:
-    # we are running in a normal Python environment
-    this_dir, this_file = os.path.split(__file__)
-
-shlib_dir = os.path.join(os.path.abspath(this_dir), 'lib')
-
-if not os.path.exists(shlib_dir):
-    raise RuntimeError('Failed to locate the Python binding in path: {}.'.format(shlib_dir))
-
-logger.info('Swig module name: {}'.format(SWIG_MODULE_NAME))
-
-sys.path.append(shlib_dir)
-driver = importlib.import_module(SWIG_MODULE_NAME)
+    raise NordicSemiException('SoftDevice API {} not supported', nrf_sd_ble_api_ver)
 
 import pc_ble_driver_py.ble_driver_types as util
 from pc_ble_driver_py.exceptions import NordicSemiException
-
-# TODO: redefine this according to what is supported in SDv2 or SDv5
-ATT_MTU_DEFAULT = 23
 
 
 def NordicSemiErrorCheck(wrapped=None, expected=driver.NRF_SUCCESS):

--- a/pc_ble_driver_py/ble_driver_types.py
+++ b/pc_ble_driver_py/ble_driver_types.py
@@ -40,12 +40,13 @@ import importlib
 import pc_ble_driver_py.config as config
 
 nrf_sd_ble_api_ver = config.sd_api_ver_get()
-# Load pc_ble_driver
-SWIG_MODULE_NAME = "_nrf_ble_driver_sd_api_v{}".format(nrf_sd_ble_api_ver)
-try:
-    ble_driver = importlib.import_module(SWIG_MODULE_NAME)
-except Exception:
-    print("Error. No ble_driver module found.")
+
+if nrf_sd_ble_api_ver == 2:
+    import pc_ble_driver_py.lib.nrf_ble_driver_sd_api_v2 as ble_driver
+elif nrf_sd_ble_api_ver == 5:
+    import pc_ble_driver_py.lib.nrf_ble_driver_sd_api_v5 as ble_driver
+else:
+    raise NordicSemiException('SoftDevice API {} not supported', nrf_sd_ble_api_ver)
 
 UNIT_0_625_MS = 625  # Unit used for scanning and advertising parameters
 UNIT_1_25_MS = 1250  # Unit used for connection interval parameters

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,8 @@ def find_version(*file_paths):
 
     raise RuntimeError("Unable to find version string.")
 
+packages = find_packages(exclude=["tests.*"])
+
 setup(
     name='pc_ble_driver_py',
     version=find_version("pc_ble_driver_py", "__init__.py"),
@@ -123,12 +125,9 @@ setup(
              'pc_ble_driver pc_ble_driver_py',
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4",
     install_requires=requirements,
-    packages=find_packages(),
+    packages=packages,
     package_data={
-        'pc_ble_driver_py.lib.win.x86_32': ['*.pyd', '*.dll', '*.txt'],
-        'pc_ble_driver_py.lib.win.x86_64': ['*.pyd', '*.dll', '*.txt'],
-        'pc_ble_driver_py.lib.linux.x86_64': ['*.so', '*.txt'],
-        'pc_ble_driver_py.lib.macos_osx': ['*.so', '*.dylib', '*.txt'],
+        'pc_ble_driver_py.lib': ['*.pyd', '*.dll', '*.txt','*.so','*.dylib'],
         'pc_ble_driver_py.hex': ['*.hex'],
         'pc_ble_driver_py.hex.sd_api_v2': ['*.hex'],
         'pc_ble_driver_py.hex.sd_api_v5': ['*.hex'],


### PR DESCRIPTION
Previously the module loaded pc-ble-driver with ctypes
and in addition to loading through the binding.

This commit changes the import of the binding to
 the one provided by SWIG and no ctypes loading
 of pc-ble-driver is necessary.