### PR TITLE
Fix/use threads not deamon threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(SWIG REQUIRED)
 include(${SWIG_USE_FILE})
 
 # nrf-ble-driver
-find_package(nrf-ble-driver CONFIG REQUIRED)
+find_package(nrf-ble-driver 4.1.0 CONFIG REQUIRED)
 
 message(STATUS "Found Python ${PYTHON_VERSION_STRING} in directory ${PYTHON_EXECUTABLE}")
 message(STATUS "Linking towards Python library ${PYTHON_LIBRARY}")

--- a/setup.py
+++ b/setup.py
@@ -51,13 +51,13 @@ requirements = []
 if py2:
     if sys.version_info[1] < 7:
         print(py_version_old_message)
-        os.exit(-1)
+        sys.exit(-1)
 
     requirements = ['enum34', 'wrapt', 'future', 'typing']
 elif py3:
     if sys.version_info[1] < 6:
         print(py_version_old_message)
-        os.exit(-1)
+        sys.exit(-1)
 
     requirements = ['wrapt', 'future']
 else:

--- a/tests/test_ble_common_api.py
+++ b/tests/test_ble_common_api.py
@@ -51,5 +51,5 @@ def test_suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 if __name__ == '__main__':
-    logging.basicConfig(level=Settings.current().log_level)
+    logging.basicConfig(level=Settings.current().log_level, format='%(asctime)s [%(thread)d/%(threadName)s] %(message)s')
     unittest.main(argv=Settings.clean_args())

--- a/tests/test_driver_open_close.py
+++ b/tests/test_driver_open_close.py
@@ -1,6 +1,7 @@
 import unittest
 from driver_setup import *
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -26,9 +27,7 @@ class DriverOpenClose(unittest.TestCase):
         logger.info('Number of iterations: %s', settings.number_of_iterations)
 
         for _ in range(0, settings.number_of_iterations):
-            logger.debug('Starting open')
             adapter.open()
-            logger.debug('Open complete')
 
             if settings.nrf_family == 'NRF51':
                 adapter.driver.ble_enable(BLEEnableParams(vs_uuid_count=1,
@@ -43,7 +42,10 @@ class DriverOpenClose(unittest.TestCase):
                 adapter.driver.ble_cfg_set(BLEConfig.conn_gatt, gatt_cfg)
                 adapter.driver.ble_enable()
 
+            adapter.driver.ble_gap_scan_start()
+            time.sleep(1)
             adapter.close()
+
 
     def tearDown(self):
         pass
@@ -54,5 +56,5 @@ def test_suite():
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=Settings.current().log_level)
+    logging.basicConfig(level=Settings.current().log_level, format='%(asctime)s [%(thread)d/%(threadName)s] %(message)s')
     unittest.main(argv=Settings.clean_args())


### PR DESCRIPTION
Previously log and status worker threads were ran as daemon threads
The code for these threads was not compatible with Python2.7.

Daemon threads may be nondeterministic and may lead to unexpected behaviour.

This PR changes this to make threads be "normal" threads. It also changes the behaviour of ble events to use the same functionality as log and status.