### PR TITLE
Azure pipeline support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
 endif()
 
 if(WIN32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_hypot=hypot")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_hypot=hypot -m32")
 endif()
 if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -std=c++11 -stdlib=libc++ -mmacosx-version-min=10.14")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(PythonExtensions REQUIRED)
 
 if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_hypot=hypot")
-else()
+endif()
 
 set(PC_BLE_DRIVER_PY_OUTDIR ${CMAKE_BINARY_DIR}/outdir)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,10 +128,10 @@ foreach(SD_API_VER ${SD_API_VERS})
         target_include_directories(${PYTHON_MODULE_${SD_API_VER}} PRIVATE ${PC_BLE_DRIVER_PY_OUTDIR})
     endif()
 
-    python_extension_module(${PYTHON_MODULE_${SD_API_VER}}
-                            LINKED_MODULES_VAR linked_module_list
-                            FORWARD_DECL_MODULES_VAR fdecl_module_list)
-    target_link_libraries(${PYTHON_MODULE_${SD_API_VER}} nrf::nrf_ble_driver_sd_api_v${SD_API_VER}_${NRF_BLE_DRIVER_LINKAGE_TYPE} ${PYTHON_LIBRARY})
+    # python_extension_module(${PYTHON_MODULE_${SD_API_VER}}
+    #                         LINKED_MODULES_VAR linked_module_list
+    #                         FORWARD_DECL_MODULES_VAR fdecl_module_list)
+    target_link_libraries(${PYTHON_MODULE_${SD_API_VER}} PRIVATE nrf::nrf_ble_driver_sd_api_v${SD_API_VER}_${NRF_BLE_DRIVER_LINKAGE_TYPE} ${PYTHON_LIBRARY})
 
     get_target_property(CONNECTIVITY_SD_API_V${SD_API_VER}_PATH nrf::nrf_ble_driver_sd_api_v${SD_API_VER}_${NRF_BLE_DRIVER_LINKAGE_TYPE} INTERFACE_INCLUDE_DIRECTORIES)
     set(CONNECTIVITY_SD_API_V${SD_API_VER}_PATH ${CONNECTIVITY_SD_API_V${SD_API_VER}_PATH}/../../share/nrf-ble-driver/hex/sd_api_v${SD_API_VER})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,9 +48,11 @@ find_package(nrf-ble-driver CONFIG REQUIRED)
 
 message(STATUS "Found Python ${PYTHON_VERSION_STRING} in directory ${PYTHON_EXECUTABLE}")
 message(STATUS "Linking towards Python library ${PYTHON_LIBRARY}")
+message(STATUS "IncludeDir ${PYTHON_INCLUDE_DIR}")
+message(STATUS "IncludeDirs ${PYTHON_INCLUDE_DIRS}")
 
 # PYTHON_INCLUDE_DIR provided by scikit-build
-include_directories(${PYTHON_INCLUDE_DIR})
+include_directories(${PYTHON_INCLUDE_DIRS})
 
 set(SWIG_I_FILE ${CMAKE_CURRENT_LIST_DIR}/swig/pc_ble_driver.i.in)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,10 @@ foreach(SD_API_VER ${SD_API_VERS})
         target_include_directories(${PYTHON_MODULE_${SD_API_VER}} PRIVATE ${PC_BLE_DRIVER_PY_OUTDIR})
     endif()
 
-    target_link_libraries(${PYTHON_MODULE_${SD_API_VER}} PRIVATE nrf::nrf_ble_driver_sd_api_v${SD_API_VER}_${NRF_BLE_DRIVER_LINKAGE_TYPE} ${PYTHON_LIBRARY})
+    python_extension_module(${PYTHON_MODULE_${SD_API_VER}}
+                            LINKED_MODULES_VAR linked_module_list
+                            FORWARD_DECL_MODULES_VAR fdecl_module_list)
+    target_link_libraries(${PYTHON_MODULE_${SD_API_VER}} nrf::nrf_ble_driver_sd_api_v${SD_API_VER}_${NRF_BLE_DRIVER_LINKAGE_TYPE} ${PYTHON_LIBRARY})
 
     get_target_property(CONNECTIVITY_SD_API_V${SD_API_VER}_PATH nrf::nrf_ble_driver_sd_api_v${SD_API_VER}_${NRF_BLE_DRIVER_LINKAGE_TYPE} INTERFACE_INCLUDE_DIRECTORIES)
     set(CONNECTIVITY_SD_API_V${SD_API_VER}_PATH ${CONNECTIVITY_SD_API_V${SD_API_VER}_PATH}/../../share/nrf-ble-driver/hex/sd_api_v${SD_API_VER})
@@ -141,10 +144,6 @@ foreach(SD_API_VER ${SD_API_VERS})
     if(APPLE)
         set_property(TARGET ${PYTHON_MODULE_${SD_API_VER}} PROPERTY SUFFIX ".so")
     endif()
-
-    python_extension_module(${PYTHON_MODULE_${SD_API_VER}}
-                            LINKED_MODULES_VAR linked_module_list
-                            FORWARD_DECL_MODULES_VAR fdecl_module_list)
 endforeach()
 
 set(BUILD_OUTPUT_LIB_DIR "pc_ble_driver_py/lib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,7 @@ endif()
 # Name of the project
 project (pc-ble-driver-py)
 
-if(DEFINED ENV{PYTHON_VERSION})
-    find_package(PythonLibs "$ENV{PYTHON_VERSION}" REQUIRED)
-else()
-    find_package(PythonLibs REQUIRED)
-endif()
+find_package(PythonExtensions)
 
 if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_hypot=hypot")
@@ -148,6 +144,10 @@ foreach(SD_API_VER ${SD_API_VERS})
     if(APPLE)
         set_property(TARGET ${PYTHON_MODULE_${SD_API_VER}} PROPERTY SUFFIX ".so")
     endif()
+
+    python_extension_module(TARGET ${PYTHON_MODULE_${SD_API_VER}}
+                            LINKED_MODULES_VAR linked_module_list
+                            FORWARD_DECL_MODULES_VAR fdecl_module_list)
 endforeach()
 
 set(BUILD_OUTPUT_LIB_DIR "pc_ble_driver_py/lib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,8 @@
 cmake_minimum_required(VERSION 3.13)
 
 if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
-    if(WIN32)
-        set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}\\scripts\\buildsystems\\vcpkg.cmake"
-            CACHE STRING "")
-    else()
-        set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-            CACHE STRING "")
-    endif()
+    set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+        CACHE STRING "")
 endif()
 
 # Name of the project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,8 @@ endif()
 # Name of the project
 project (pc-ble-driver-py)
 
-if(DEFINED ENV{PYTHON_VERSION} AND NOT WIN32 AND NOT APPLE)
-    find_program(PYTHON_CONFIG NAMES "python$ENV{PYTHON_VERSION}-config")
+if(DEFINED ENV{PYTHON_VERSION} AND NOT WIN32)
+    find_program(PYTHON_CONFIG NAMES "python$ENV{PYTHON_VERSION}-config" python-config)
     message(STATUS "Python config command: ${PYTHON_CONFIG}")
     exec_program(${PYTHON_CONFIG}
         ARGS "--includes"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,28 +13,21 @@ endif()
 # Name of the project
 project (pc-ble-driver-py)
 
-if(DEFINED ENV{PYTHON_VERSION} AND NOT WIN32)
-    find_program(PYTHON_CONFIG NAMES "python$ENV{PYTHON_VERSION}-config" python-config)
-    message(STATUS "Python config command: ${PYTHON_CONFIG}")
-    exec_program(${PYTHON_CONFIG}
-        ARGS "--includes"
-        OUTPUT_VARIABLE PYTHON_CFLAGS)
-    exec_program(${PYTHON_CONFIG}
-        ARGS "--ldflags"
-        OUTPUT_VARIABLE PYTHON_LDFLAGS)
-
-    set(CMAKE_CXX_FLAGS "${PYTHON_CFLAGS}")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${PYTHON_LDFLAGS} -stdlib=libc++ -lc++abi")
+if(DEFINED ENV{PYTHON_VERSION})
+    find_package(PythonLibs "$ENV{PYTHON_VERSION}" REQUIRED)
 else()
     find_package(PythonLibs REQUIRED)
 endif()
 
 if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_hypot=hypot")
+else()
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
 endif()
 if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
 endif()
+
 message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 message(STATUS "CMAKE_EXE_LINKER_FLAGS: ${CMAKE_EXE_LINKER_FLAGS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 # Name of the project
 project (pc-ble-driver-py)
 
-find_package(PythonExtensions)
+find_package(PythonExtensions REQUIRED)
 
 if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_hypot=hypot")
@@ -42,13 +42,10 @@ include(${SWIG_USE_FILE})
 # nrf-ble-driver
 find_package(nrf-ble-driver CONFIG REQUIRED)
 
-message(STATUS "Found Python ${PYTHON_VERSION_STRING} in directory ${PYTHON_EXECUTABLE}")
-message(STATUS "Linking towards Python library ${PYTHON_LIBRARY}")
 message(STATUS "IncludeDir ${PYTHON_INCLUDE_DIR}")
-message(STATUS "IncludeDirs ${PYTHON_INCLUDE_DIRS}")
 
 # PYTHON_INCLUDE_DIR provided by scikit-build
-include_directories(${PYTHON_INCLUDE_DIRS})
+include_directories(${PYTHON_INCLUDE_DIR})
 
 set(SWIG_I_FILE ${CMAKE_CURRENT_LIST_DIR}/swig/pc_ble_driver.i.in)
 
@@ -145,7 +142,7 @@ foreach(SD_API_VER ${SD_API_VERS})
         set_property(TARGET ${PYTHON_MODULE_${SD_API_VER}} PROPERTY SUFFIX ".so")
     endif()
 
-    python_extension_module(TARGET ${PYTHON_MODULE_${SD_API_VER}}
+    python_extension_module(${PYTHON_MODULE_${SD_API_VER}}
                             LINKED_MODULES_VAR linked_module_list
                             FORWARD_DECL_MODULES_VAR fdecl_module_list)
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,6 @@ include(${SWIG_USE_FILE})
 # nrf-ble-driver
 find_package(nrf-ble-driver CONFIG REQUIRED)
 
-message(STATUS "IncludeDir ${PYTHON_INCLUDE_DIR}")
-
 # PYTHON_INCLUDE_DIR provided by scikit-build
 include_directories(${PYTHON_INCLUDE_DIR})
 
@@ -128,9 +126,6 @@ foreach(SD_API_VER ${SD_API_VERS})
         target_include_directories(${PYTHON_MODULE_${SD_API_VER}} PRIVATE ${PC_BLE_DRIVER_PY_OUTDIR})
     endif()
 
-    # python_extension_module(${PYTHON_MODULE_${SD_API_VER}}
-    #                         LINKED_MODULES_VAR linked_module_list
-    #                         FORWARD_DECL_MODULES_VAR fdecl_module_list)
     target_link_libraries(${PYTHON_MODULE_${SD_API_VER}} PRIVATE nrf::nrf_ble_driver_sd_api_v${SD_API_VER}_${NRF_BLE_DRIVER_LINKAGE_TYPE} ${PYTHON_LIBRARY})
 
     get_target_property(CONNECTIVITY_SD_API_V${SD_API_VER}_PATH nrf::nrf_ble_driver_sd_api_v${SD_API_VER}_${NRF_BLE_DRIVER_LINKAGE_TYPE} INTERFACE_INCLUDE_DIRECTORIES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
 endif()
 
 if(WIN32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_hypot=hypot -m32")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_hypot=hypot")
 endif()
 if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -std=c++11 -stdlib=libc++ -mmacosx-version-min=10.14")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,15 +13,6 @@ find_package(PythonExtensions REQUIRED)
 if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_hypot=hypot")
 else()
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
-endif()
-if(APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
-endif()
-
-message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
-message(STATUS "CMAKE_EXE_LINKER_FLAGS: ${CMAKE_EXE_LINKER_FLAGS}")
-
 
 set(PC_BLE_DRIVER_PY_OUTDIR ${CMAKE_BINARY_DIR}/outdir)
 
@@ -114,6 +105,8 @@ foreach(SD_API_VER ${SD_API_VERS})
         SOURCES ${SWIG_I_FILE_${SD_API_VER}}
         OUTPUT_DIR ${PC_BLE_DRIVER_PY_OUTDIR}
     )
+
+    set_property(TARGET ${PYTHON_MODULE_${SD_API_VER}} PROPERTY CXX_STANDARD 14)
 
     set_source_files_properties(${PC_BLE_DRIVER_PY_OUTDIR}/${PYTHON_MODULE_${SD_API_VER}}PYTHON_wrap.c PROPERTIES LANGUAGE CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 # Name of the project
 project (pc-ble-driver-py)
 
-if(DEFINED ENV{PYTHON_VERSION} AND NOT WIN32)
+if(DEFINED ENV{PYTHON_VERSION} AND NOT WIN32 AND NOT APPLE)
     find_program(PYTHON_CONFIG NAMES "python$ENV{PYTHON_VERSION}-config")
     message(STATUS "Python config command: ${PYTHON_CONFIG}")
     exec_program(${PYTHON_CONFIG}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_hypot=hypot")
 endif()
 if(APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -std=c++11 -stdlib=libc++ -mmacosx-version-min=10.14")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
 endif()
 message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 message(STATUS "CMAKE_EXE_LINKER_FLAGS: ${CMAKE_EXE_LINKER_FLAGS}")
@@ -150,6 +150,9 @@ foreach(SD_API_VER ${SD_API_VERS})
         TARGET ${PYTHON_MODULE_${SD_API_VER}}
         PROPERTY RESOURCE "${CONNECTIVITY_SD_API_V${SD_API_VER}_FILES}"
     )
+    if(APPLE)
+        set_property(TARGET ${PYTHON_MODULE_${SD_API_VER}} PROPERTY SUFFIX ".so")
+    endif()
 endforeach()
 
 set(BUILD_OUTPUT_LIB_DIR "pc_ble_driver_py/lib")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,7 +99,7 @@ jobs:
         sudo xcode-select -s /Applications/Xcode_10.1.app
       displayName: 'Install toolchain'
     - script: |
-        brew install swig
+        brew install gcc swig
       displayName: 'Install toolchain'
     # - script: |
     #     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-$(conda_version).sh -O $(Agent.HomeDirectory)/miniconda.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -184,10 +184,9 @@ jobs:
     - bash: |
         pypath=`which python`
         pyroot=`dirname ${pypath}`
-        find ${pyroot}
-        pyheader=`ls ${pyroot}/include/python*/Python.h`
+        pyheader=`ls ${pyroot}/include/Python.h`
         pyincldir=`dirname ${pyheader}`
-        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
+        pylib=`ls ${pyroot}/libs/libpython*.a`
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "Visual Studio 15 2017 Win64"
       condition: eq(variables['python_arch'], 'x64')
@@ -195,10 +194,9 @@ jobs:
     - bash: |
         pypath=`which python`
         pyroot=`dirname ${pypath}`
-        find ${pyroot}
-        pyheader=`ls ${pyroot}/include/python*/Python.h`
+        pyheader=`ls ${pyroot}/include/Python.h`
         pyincldir=`dirname ${pyheader}`
-        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
+        pylib=`ls ${pyroot}/libs/libpython*.a`
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "Visual Studio 15 2017"
       condition: eq(variables['python_arch'], 'x86')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,11 +81,9 @@ jobs:
     pool:
       vmImage: 'macos-10.13'
     steps:
-    - task: Xcode@5
-      inputs:
-        actions: 'build'
-        xcodeVersion: '10'
-        xcWorkspacePath: ''
+    - script: |
+        xcode-select /Applications/Xcode_10.1.app
+      displayName: 'Install toolchain'
     - script: |
         brew install gcc swig
       displayName: 'Install toolchain'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,7 +83,7 @@ jobs:
     steps:
     - script: |
         ls /Applications
-        sudo xcode-select -s /Applications/Xcode_9.4.1.app
+        sudo xcode-select -s /Applications/Xcode_10.1.app
       displayName: 'Install toolchain'
     - script: |
         brew install gcc swig
@@ -111,7 +111,7 @@ jobs:
         export PATH=$(conda_root)/envs/python$(python_version)/bin:$PATH
         export PYTHON_VERSION=$(python_version)
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Debug
+        python setup.py bdist_wheel --build-type Debug -- -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14
       env: {
         VCPKG_ROOT: '$(Agent.HomeDirectory)/vcpkg',
       }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,28 +118,44 @@ jobs:
       vcpkg_root: '$(Agent.HomeDirectory)\vcpkg'
     strategy:
       matrix:
+        win64_python_27:
+          python_version: 2.7
+          python_arch: 'x64'
+          triplet: 'x64-windows'
+        win64_python_35:
+          python_version: 3.5
+          python_arch: 'x64'
+          triplet: 'x64-windows'
         win64_python_36:
           python_version: 3.6
           python_arch: 'x64'
           triplet: 'x64-windows'
+        win64_python_37:
+          python_version: 3.7
+          python_arch: 'x64'
+          triplet: 'x64-windows'
+        win32_python_27:
+          python_version: 2.7
+          python_arch: 'x86'
+          triplet: 'x86-windows'
+        win32_python_35:
+          python_version: 3.5
+          python_arch: 'x86'
+          triplet: 'x86-windows'
         win32_python_36:
           python_version: 3.6
+          python_arch: 'x86'
+          triplet: 'x86-windows'
+        win32_python_37:
+          python_version: 3.7
           python_arch: 'x86'
           triplet: 'x86-windows'
     pool:
       vmImage: 'vs2017-win2016'
     steps:
-    # - script: |
-    #     choco install -y --x86 swig
-    #     choco install -y --x86 ninja
-    #     choco install -y miniconda3 --params="'/D:$(conda_root)'"
-    #   condition: eq(variables['python_arch'], 'x86')
-    #   displayName: 'Install toolchain on Windows'
     - script: |
         choco install -y --x86 swig
-        choco install -y ninja
         choco install -y miniconda3 --params="'/D:$(conda_root)'"
-      # condition: eq(variables['python_arch'], 'x64')
       displayName: 'Install toolchain on Windows'
     - script: |
         $(conda_root)\Scripts\conda create -yq -n python$(python_version) python=$(python_version)
@@ -171,11 +187,7 @@ jobs:
       condition: eq(variables['python_arch'], 'x64')
       displayName: 'Build'
     - script: |
-        call set CONDA_FORCE_32BIT=1
         call $(conda_root)\Scripts\activate python$(python_version)
-        call set
-        python --version
-        python version.py
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Debug -- -G "Visual Studio 15 2017"
       env: {
@@ -183,43 +195,6 @@ jobs:
       }
       condition: eq(variables['python_arch'], 'x86')
       displayName: 'Build'
-
-
-
-    # # Install nrf-ble-driver
-    # - script: |
-    #     git clone https://github.com/NordicPlayground/vcpkg.git $(Agent.HomeDirectory)/vcpkg
-    #     $(Agent.HomeDirectory)/vcpkg/bootstrap-vcpkg.sh
-    #   condition: not(contains(variables['image_name'], 'win'))
-    #   displayName: 'Install nrf-ble-driver for Linux or macOS'
-    # - script: |
-    #     export PATH=$VCPKG_ROOT:$PATH
-    #     echo $PATH
-    #     echo $VCPKG_ROOT
-    #     vcpkg install nrf-ble-driver:$(triplet)
-    #   condition: not(contains(variables['image_name'], 'win'))
-    #   env: {
-    #     VCPKG_ROOT: '$(Agent.HomeDirectory)/vcpkg',
-    #   }
-    #   displayName: 'Install nrf-ble-driver for Linux or macOS'
-    # - script: |
-    #     git clone https://github.com/NordicPlayground/vcpkg.git $(Agent.HomeDirectory)/vcpkg
-    #     $(Agent.HomeDirectory)\vcpkg\bootstrap-vcpkg.bat
-    #   condition: contains(variables['image_name'], 'win')
-    #   env: {
-    #     VCPKG_ROOT: '$(Agent.HomeDirectory)\vcpkg',
-    #   }
-    #   displayName: 'Install nrf-ble-driver for Windows'
-    # - script: |
-    #     set PATH=%VCPKG_ROOT%;%PATH%
-    #     echo %PATH%
-    #     echo %VCPKG_ROOT%
-    #     vcpkg install nrf-ble-driver:$(triplet)
-    #   condition: contains(variables['image_name'], 'win')
-    #   env: {
-    #     VCPKG_ROOT: '$(Agent.HomeDirectory)\vcpkg',
-    #   }
-    #   displayName: 'Install nrf-ble-driver for Windows'
 
     # Build
     # - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -181,6 +181,7 @@ jobs:
         call set CONDA_FORCE_32BIT=1
         call $(conda_root)\Scripts\activate python$(python_version)
         call set
+        python --version
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Debug
       env: {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,8 @@
 trigger:
+- feature/s132v5_py3
 - test-azure
+- master
+- release/*
 
 jobs:
   # Linux
@@ -294,6 +297,6 @@ jobs:
   #       connectionType: 'connectedServiceName'
   #       serviceConnection: 'waylandJenkins'
   #       method: 'POST'
-  #       urlSuffix: 'view/pc-nrfjprog-js/job/pc-nrfjprog-js-$(osType)/buildWithParameters?BRANCH=$(Build.SourceBranch)&VSTS_URL=$(system.CollectionUri)&TOKEN=$(system.AccessToken)&PROJECT_ID=$(system.teamProjectId)&HUB_NAME=$(system.hostType)&PLAN_ID=$(system.planId)&TASK_ID=$(system.taskInstanceId)&JOB_ID=$(system.jobId)'
+  #       urlSuffix: 'view/pc-ble-driver-py/job/pc-ble-driver-py-$(osType)/buildWithParameters?BRANCH=$(Build.SourceBranch)&VSTS_URL=$(system.CollectionUri)&TOKEN=$(system.AccessToken)&PROJECT_ID=$(system.teamProjectId)&HUB_NAME=$(system.hostType)&PLAN_ID=$(system.planId)&TASK_ID=$(system.taskInstanceId)&JOB_ID=$(system.jobId)'
   #       waitForCompletion: 'true'
   #     condition: ne(variables['Build.Reason'], 'PullRequest')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
       displayName: 'Install nrf-ble-driver'
     - script: |
         $(conda_root)/bin/conda create -yq -n python2.7 python=2.7
-      displayName: 'Install Python 3.5'
+      displayName: 'Install Python 2.7'
     - bash: |
         export PATH=$(conda_root)/envs/python2.7/bin:$PATH
         rm -rf _skbuild

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,7 +111,7 @@ jobs:
         export PATH=$(conda_root)/envs/python$(python_version)/bin:$PATH
         export PYTHON_VERSION=$(python_version)
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Debug -- -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14
+        python setup.py bdist_wheel --build-type Debug -- -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
       env: {
         VCPKG_ROOT: '$(Agent.HomeDirectory)/vcpkg',
       }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,61 +106,55 @@ jobs:
         export PATH=$VCPKG_ROOT:$PATH
         vcpkg install nrf-ble-driver:$(python_arch)-osx
       displayName: 'Install nrf-ble-driver'
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '2.7'
-        architecture: '$(python_arch)'
+    # - task: UsePythonVersion@0
+    #   inputs:
+    #     versionSpec: '2.7'
+    #     architecture: '$(python_arch)'
+    - bash: |
+        wget https://www.python.org/ftp/python/2.7.16/python-2.7.16-macosx10.9.pkg
+        wget https://www.python.org/ftp/python/3.5.4/python-3.5.4-macosx10.6.pkg
+        wget https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg
+        wget https://www.python.org/ftp/python/3.7.3/python-3.7.3-macosx10.9.pkg
+        sudo installer -pkg python-2.7.16-macosx10.9.pkg -target /
+        sudo installer -pkg python-3.5.4-macosx10.6.pkg -target /
+        sudo installer -pkg python-3.6.8-macosx10.9.pkg -target /
+        sudo installer -pkg python-3.7.3-macosx10.9.pkg -target /
+      displayName: 'Install all pythons'
     - bash: |
         rm -rf _skbuild
-        pypath=`which python`
-        pyroot=`dirname ${pypath}`
-        pyheader=`ls ${pyroot}/include/python*/Python.h`
-        pyincldir=`dirname ${pyheader}`
-        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
-        pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
+        pypath=`which python2.7`
+        ${pypath} -m pip install -r requirements-dev.txt
+        ${pypath} setup.py bdist_wheel --build-type RelWithDebInfo -- -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
       displayName: 'Build for python 2.7'
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.5'
-        architecture: '$(python_arch)'
+    # - task: UsePythonVersion@0
+    #   inputs:
+    #     versionSpec: '3.5'
+    #     architecture: '$(python_arch)'
     - bash: |
         rm -rf _skbuild
-        pypath=`which python`
-        pyroot=`dirname ${pypath}`
-        pyheader=`ls ${pyroot}/include/python*/Python.h`
-        pyincldir=`dirname ${pyheader}`
-        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
-        pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
+        pypath=`which python3.5`
+        ${pypath} -m pip install -r requirements-dev.txt
+        ${pypath} setup.py bdist_wheel --build-type RelWithDebInfo -- -DCMAKE_OSX_DEPLOYMENT_TARGET=10.6
       displayName: 'Build for python 3.5'
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.6'
-        architecture: '$(python_arch)'
+    # - task: UsePythonVersion@0
+    #   inputs:
+    #     versionSpec: '3.6'
+    #     architecture: '$(python_arch)'
     - bash: |
         rm -rf _skbuild
-        pypath=`which python`
-        pyroot=`dirname ${pypath}`
-        pyheader=`ls ${pyroot}/include/python*/Python.h`
-        pyincldir=`dirname ${pyheader}`
-        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
-        pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
+        pypath=`which python3.6`
+        ${pypath} -m pip install -r requirements-dev.txt
+        ${pypath} setup.py bdist_wheel --build-type RelWithDebInfo -- -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
       displayName: 'Build for python 3.6'
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.7'
-        architecture: '$(python_arch)'
+    # - task: UsePythonVersion@0
+    #   inputs:
+    #     versionSpec: '3.7'
+    #     architecture: '$(python_arch)'
     - bash: |
         rm -rf _skbuild
-        pypath=`which python`
-        pyroot=`dirname ${pypath}`
-        pyheader=`ls ${pyroot}/include/python*/Python.h`
-        pyincldir=`dirname ${pyheader}`
-        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
-        pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
+        pypath=`which python3.7`
+        ${pypath} -m pip install -r requirements-dev.txt
+        ${pypath} setup.py bdist_wheel --build-type RelWithDebInfo -- -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
       displayName: 'Build for python 3.7'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -210,6 +210,7 @@ jobs:
       displayName: 'Install nrf-ble-driver'
     - script: |
         call $(conda_root)\Scripts\activate python$(python_version)
+        pip install --upgrade pip
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Debug -- -G "Visual Studio 15 2017 Win64"
       env: {
@@ -219,6 +220,7 @@ jobs:
       displayName: 'Build'
     - script: |
         call $(conda_root)\Scripts\activate python$(python_version)
+        pip install --upgrade pip
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Debug -- -G "Visual Studio 15 2017"
       env: {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -180,7 +180,7 @@ jobs:
         call $(conda_root)\Scripts\activate python$(python_version)
         set
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Debug
+        python setup.py bdist_wheel --build-type Debug -- -DCMAKE_GENERATOR_PLATFORM=x86
       env: {
         VCPKG_ROOT: '$(vcpkg_root)',
       }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,8 @@ jobs:
   # Linux
   - job: Linux
     variables:
+      conda_version: 'Linux-x86_64'
+      conda_root: '$(Agent.HomeDirectory)/miniconda3'
       VCPKG_ROOT: '$(Agent.HomeDirectory)/vcpkg'
       python_arch: 'x64'
     pool:
@@ -15,6 +17,10 @@ jobs:
         sudo apt-get install ninja-build swig libudev-dev
       displayName: 'Install toolchain'
     - script: |
+        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-$(conda_version).sh -O $(Agent.HomeDirectory)/miniconda.sh
+        bash $(Agent.HomeDirectory)/miniconda.sh -b -p $(conda_root)
+      displayName: 'Install conda'
+    - script: |
         git clone https://github.com/NordicPlayground/vcpkg.git $(VCPKG_ROOT)
         $(VCPKG_ROOT)/bootstrap-vcpkg.sh
       displayName: 'Install vcpkg'
@@ -22,61 +28,41 @@ jobs:
         export PATH=$VCPKG_ROOT:$PATH
         vcpkg install nrf-ble-driver:$(python_arch)-linux
       displayName: 'Install nrf-ble-driver'
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '2.7'
-        architecture: '$(python_arch)'
+    - script: |
+        $(conda_root)/bin/conda create -yq -n python2.7 python=2.7
+      displayName: 'Install Python 3.5'
     - bash: |
+        export PATH=$(conda_root)/envs/python2.7/bin:$PATH
         rm -rf _skbuild
-        pypath=`which python`
-        pyroot=`dirname ${pypath}`
-        pyheader=`ls ${pyroot}/include/python*/Python.h`
-        pyincldir=`dirname ${pyheader}`
-        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
+        python setup.py bdist_wheel --build-type RelWithDebInfo
       displayName: 'Build for python 2.7'
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.5'
-        architecture: '$(python_arch)'
+    - script: |
+        $(conda_root)/bin/conda create -yq -n python3.5 python=3.5
+      displayName: 'Install Python 3.5'
     - bash: |
+        export PATH=$(conda_root)/envs/python3.5/bin:$PATH
         rm -rf _skbuild
-        pypath=`which python`
-        pyroot=`dirname ${pypath}`
-        pyheader=`ls ${pyroot}/include/python*/Python.h`
-        pyincldir=`dirname ${pyheader}`
-        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
+        python setup.py bdist_wheel --build-type RelWithDebInfo
       displayName: 'Build for python 3.5'
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.6'
-        architecture: '$(python_arch)'
+    - script: |
+        $(conda_root)/bin/conda create -yq -n python3.6 python=3.6
+      displayName: 'Install Python 3.6'
     - bash: |
+        export PATH=$(conda_root)/envs/python3.6/bin:$PATH
         rm -rf _skbuild
-        pypath=`which python`
-        pyroot=`dirname ${pypath}`
-        pyheader=`ls ${pyroot}/include/python*/Python.h`
-        pyincldir=`dirname ${pyheader}`
-        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
+        python setup.py bdist_wheel --build-type RelWithDebInfo
       displayName: 'Build for python 3.6'
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.7'
-        architecture: '$(python_arch)'
+    - script: |
+        $(conda_root)/bin/conda create -yq -n python3.7 python=3.7
+      displayName: 'Install Python 3.7'
     - bash: |
+        export PATH=$(conda_root)/envs/python3.7/bin:$PATH
         rm -rf _skbuild
-        pypath=`which python`
-        pyroot=`dirname ${pypath}`
-        pyheader=`ls ${pyroot}/include/python*/Python.h`
-        pyincldir=`dirname ${pyheader}`
-        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
+        python setup.py bdist_wheel --build-type RelWithDebInfo
       displayName: 'Build for python 3.7'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,7 @@ jobs:
         which pip
         python --version
         pip --version
+        find /opt/hostedtoolcache/Python
       displayName: 'Dig python'
     # - script: |
     #     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-$(conda_version).sh -O $(Agent.HomeDirectory)/miniconda.sh
@@ -109,6 +110,7 @@ jobs:
         which pip
         DYLD_PRINT_LIBRARIES=1 python --version
         pip --version
+        find /Users/vsts/hostedtoolcache/Python
       displayName: 'Dig python'
     - script: |
         ls /Applications
@@ -201,26 +203,37 @@ jobs:
     pool:
       vmImage: 'vs2017-win2016'
     steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '$(python_version)'
+        architecture: '$(python_arch)'
+    - bash: |
+        which python
+        which pip
+        python --version
+        pip --version
+        find /c/vsts/hostedtoolcache/Python
+      displayName: 'Dig python'
     - script: |
         choco install -y --x86 swig
-        choco install -y miniconda3 --params="'/D:$(conda_root)'"
-      condition: ne(variables['python_version'], '2.7')
+        # choco install -y miniconda3 --params="'/D:$(conda_root)'"
+      # condition: ne(variables['python_version'], '2.7')
       displayName: 'Install toolchain on Windows'
     - script: |
         choco install -y --x86 swig
-        choco install -y miniconda3 --params="'/D:$(conda_root)'"
+        # choco install -y miniconda3 --params="'/D:$(conda_root)'"
         choco install -y vcpython27
       condition: eq(variables['python_version'], '2.7')
       displayName: 'Install toolchain on Windows for Python 2.7'
-    - script: |
-        $(conda_root)\Scripts\conda create -yq -n python$(python_version) python=$(python_version)
-      condition: eq(variables['python_arch'], 'x64')
-      displayName: 'Install Python $(python_version)'
-    - script: |
-        call set CONDA_FORCE_32BIT=1
-        $(conda_root)\Scripts\conda create -yq -n python$(python_version) python=$(python_version)
-      condition: eq(variables['python_arch'], 'x86')
-      displayName: 'Install Python $(python_version)'
+    # - script: |
+    #     $(conda_root)\Scripts\conda create -yq -n python$(python_version) python=$(python_version)
+    #   condition: eq(variables['python_arch'], 'x64')
+    #   displayName: 'Install Python $(python_version)'
+    # - script: |
+    #     call set CONDA_FORCE_32BIT=1
+    #     $(conda_root)\Scripts\conda create -yq -n python$(python_version) python=$(python_version)
+    #   condition: eq(variables['python_arch'], 'x86')
+    #   displayName: 'Install Python $(python_version)'
     - script: |
         git clone https://github.com/NordicPlayground/vcpkg.git $(vcpkg_root)
         $(vcpkg_root)\bootstrap-vcpkg.bat
@@ -233,7 +246,7 @@ jobs:
       }
       displayName: 'Install nrf-ble-driver'
     - script: |
-        call $(conda_root)\Scripts\activate python$(python_version)
+        # call $(conda_root)\Scripts\activate python$(python_version)
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Release -- -G "Visual Studio 15 2017 Win64"
       env: {
@@ -242,7 +255,7 @@ jobs:
       condition: eq(variables['python_arch'], 'x64')
       displayName: 'Build'
     - script: |
-        call $(conda_root)\Scripts\activate python$(python_version)
+        # call $(conda_root)\Scripts\activate python$(python_version)
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Release -- -G "Visual Studio 15 2017"
       env: {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,21 +5,21 @@ jobs:
   # Linux
   - job: Linux_Build
     variables:
-      conda_version: 'Linux-x86_64'
-      conda_root: '$(Agent.HomeDirectory)/miniconda3'
-      vcpkg_root: '$(Agent.HomeDirectory)/vcpkg'
+      # conda_version: 'Linux-x86_64'
+      # conda_root: '$(Agent.HomeDirectory)/miniconda3'
+      VCPKG_ROOT: '$(Agent.HomeDirectory)/vcpkg'
       python_arch: 'x64'
       triplet: 'x64-linux'
     strategy:
       matrix:
         linux_python_27:
-          python_version: 2.7
+          PYTHON_VERSION: 2.7
         linux_python_35:
-          python_version: 3.5
+          PYTHON_VERSION: 3.5
         linux_python_36:
-          python_version: 3.6
+          PYTHON_VERSION: 3.6
         linux_python_37:
-          python_version: 3.7
+          PYTHON_VERSION: 3.7
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
@@ -29,40 +29,33 @@ jobs:
       displayName: 'Install toolchain'
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '$(python_version)'
+        versionSpec: '$(PYTHON_VERSION)'
         architecture: 'x64'
-    - script: |
-        which python
-        which pip
-        python --version
-        pip --version
-        find /opt/hostedtoolcache/Python
-      displayName: 'Dig python'
+    # - script: |
+    #     which python
+    #     which pip
+    #     python --version
+    #     pip --version
+    #     find /opt/hostedtoolcache/Python
+    #   displayName: 'Dig python'
     # - script: |
     #     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-$(conda_version).sh -O $(Agent.HomeDirectory)/miniconda.sh
     #     bash $(Agent.HomeDirectory)/miniconda.sh -b -p $(conda_root)
     #   displayName: 'Install conda'
     # - script: |
-    #     $(conda_root)/bin/conda create -yq -n python$(python_version) python=$(python_version)
-    #   displayName: 'Install Python $(python_version)'
+    #     $(conda_root)/bin/conda create -yq -n python$(PYTHON_VERSION) python=$(PYTHON_VERSION)
+    #   displayName: 'Install Python $(PYTHON_VERSION)'
     - script: |
-        git clone https://github.com/NordicPlayground/vcpkg.git $(vcpkg_root)
-        $(vcpkg_root)/bootstrap-vcpkg.sh
+        git clone https://github.com/NordicPlayground/vcpkg.git $(VCPKG_ROOT)
+        $(VCPKG_ROOT)/bootstrap-vcpkg.sh
       displayName: 'Install vcpkg'
     - script: |
         export PATH=$VCPKG_ROOT:$PATH
         vcpkg install nrf-ble-driver:$(triplet)
-      env: {
-        VCPKG_ROOT: '$(vcpkg_root)',
-      }
       displayName: 'Install nrf-ble-driver'
     - script: |
-        # export PATH=$(conda_root)/envs/python$(python_version)/bin:$PATH
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Release
-      env: {
-        VCPKG_ROOT: '$(vcpkg_root)',
-      }
       displayName: 'Build'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
@@ -83,35 +76,38 @@ jobs:
   # macOS
   - job: macOS_Build
     variables:
-      conda_version: 'MacOSX-x86_64'
-      conda_root: '$(Agent.HomeDirectory)/miniconda3'
-      vcpkg_root: '$(Agent.HomeDirectory)/vcpkg'
+      # conda_version: 'MacOSX-x86_64'
+      # conda_root: '$(Agent.HomeDirectory)/miniconda3'
+      VCPKG_ROOT: '$(Agent.HomeDirectory)/vcpkg'
       python_arch: 'x64'
       triplet: 'x64-osx'
     strategy:
       matrix:
         mac_python_27:
-          python_version: 2.7
+          PYTHON_VERSION: 2.7
         mac_python_35:
-          python_version: 3.5
+          PYTHON_VERSION: 3.5
         mac_python_36:
-          python_version: 3.6
+          PYTHON_VERSION: 3.6
         mac_python_37:
-          python_version: 3.7
+          PYTHON_VERSION: 3.7
     pool:
       vmImage: 'macos-10.13'
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '$(python_version)'
+        versionSpec: '$(PYTHON_VERSION)'
         architecture: 'x64'
-    - script: |
-        which python
-        which pip
-        DYLD_PRINT_LIBRARIES=1 python --version
-        pip --version
-        find /Users/vsts/hostedtoolcache/Python
-      displayName: 'Dig python'
+    # - script: |
+    #     python_path=`which python`
+    #     python_dir=`dirname python`
+    #     python_incl=${python_dir}/include/python$(PYTHON_VERSION)
+    #     python_lib=
+    #     which pip
+    #     DYLD_PRINT_LIBRARIES=1 python --version
+    #     pip --version
+    #     ls "/Users/vsts/hostedtoolcache/Python$(PYTHON_VERSION).*/x64/include/python2.7"
+    #   displayName: 'Dig python'
     - script: |
         ls /Applications
         sudo xcode-select -s /Applications/Xcode_10.1.app
@@ -124,27 +120,21 @@ jobs:
     #     bash $(Agent.HomeDirectory)/miniconda.sh -b -p $(conda_root)
     #   displayName: 'Install conda'
     # - script: |
-    #     $(conda_root)/bin/conda create -yq -n python$(python_version) python=$(python_version)
-    #   displayName: 'Install Python $(python_version)'
+    #     $(conda_root)/bin/conda create -yq -n python$(PYTHON_VERSION) python=$(PYTHON_VERSION)
+    #   displayName: 'Install Python $(PYTHON_VERSION)'
     - script: |
-        git clone https://github.com/NordicPlayground/vcpkg.git $(vcpkg_root)
-        $(vcpkg_root)/bootstrap-vcpkg.sh
+        git clone https://github.com/NordicPlayground/vcpkg.git $(VCPKG_ROOT)
+        $(VCPKG_ROOT)/bootstrap-vcpkg.sh
       displayName: 'Install vcpkg'
     - script: |
         export PATH=$VCPKG_ROOT:$PATH
         vcpkg install nrf-ble-driver:$(triplet)
-      env: {
-        VCPKG_ROOT: '$(Agent.HomeDirectory)/vcpkg',
-      }
       displayName: 'Install nrf-ble-driver'
     - script: |
-        # export PATH=$(conda_root)/envs/python$(python_version)/bin:$PATH
-        # export PYTHON_VERSION=$(python_version)
+        # export PATH=$(conda_root)/envs/python$(PYTHON_VERSION)/bin:$PATH
+        export
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Release -- -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
-      env: {
-        VCPKG_ROOT: '$(Agent.HomeDirectory)/vcpkg',
-      }
       displayName: 'Build'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
@@ -164,40 +154,40 @@ jobs:
   # Windows
   - job: Windows_Build
     variables:
-      conda_root: '$(Agent.HomeDirectory)\miniconda3'
-      vcpkg_root: '$(Agent.HomeDirectory)\vcpkg'
+      # conda_root: '$(Agent.HomeDirectory)\miniconda3'
+      VCPKG_ROOT: '$(Agent.HomeDirectory)\vcpkg'
     strategy:
       matrix:
         win64_python_27:
-          python_version: 2.7
+          PYTHON_VERSION: 2.7
           python_arch: 'x64'
           triplet: 'x64-windows'
         win64_python_35:
-          python_version: 3.5
+          PYTHON_VERSION: 3.5
           python_arch: 'x64'
           triplet: 'x64-windows'
         win64_python_36:
-          python_version: 3.6
+          PYTHON_VERSION: 3.6
           python_arch: 'x64'
           triplet: 'x64-windows'
         win64_python_37:
-          python_version: 3.7
+          PYTHON_VERSION: 3.7
           python_arch: 'x64'
           triplet: 'x64-windows'
         win32_python_27:
-          python_version: 2.7
+          PYTHON_VERSION: 2.7
           python_arch: 'x86'
           triplet: 'x86-windows'
         win32_python_35:
-          python_version: 3.5
+          PYTHON_VERSION: 3.5
           python_arch: 'x86'
           triplet: 'x86-windows'
         win32_python_36:
-          python_version: 3.6
+          PYTHON_VERSION: 3.6
           python_arch: 'x86'
           triplet: 'x86-windows'
         win32_python_37:
-          python_version: 3.7
+          PYTHON_VERSION: 3.7
           python_arch: 'x86'
           triplet: 'x86-windows'
     pool:
@@ -205,62 +195,53 @@ jobs:
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '$(python_version)'
+        versionSpec: '$(PYTHON_VERSION)'
         architecture: '$(python_arch)'
-    - bash: |
-        which python
-        which pip
-        python --version
-        pip --version
-        find /c/vsts/hostedtoolcache/Python
-      displayName: 'Dig python'
+    # - bash: |
+    #     which python
+    #     which pip
+    #     python --version
+    #     pip --version
+    #     find /c/hostedtoolcache/Python
+    #   displayName: 'Dig python'
     - script: |
         choco install -y --x86 swig
         # choco install -y miniconda3 --params="'/D:$(conda_root)'"
-      # condition: ne(variables['python_version'], '2.7')
+      # condition: ne(variables['PYTHON_VERSION'], '2.7')
       displayName: 'Install toolchain on Windows'
-    - script: |
-        choco install -y --x86 swig
-        # choco install -y miniconda3 --params="'/D:$(conda_root)'"
-        choco install -y vcpython27
-      condition: eq(variables['python_version'], '2.7')
-      displayName: 'Install toolchain on Windows for Python 2.7'
     # - script: |
-    #     $(conda_root)\Scripts\conda create -yq -n python$(python_version) python=$(python_version)
+    #     choco install -y --x86 swig
+    #     # choco install -y miniconda3 --params="'/D:$(conda_root)'"
+    #     choco install -y vcpython27
+    #   condition: eq(variables['PYTHON_VERSION'], '2.7')
+    #   displayName: 'Install toolchain on Windows for Python 2.7'
+    # - script: |
+    #     $(conda_root)\Scripts\conda create -yq -n python$(PYTHON_VERSION) python=$(PYTHON_VERSION)
     #   condition: eq(variables['python_arch'], 'x64')
-    #   displayName: 'Install Python $(python_version)'
+    #   displayName: 'Install Python $(PYTHON_VERSION)'
     # - script: |
     #     call set CONDA_FORCE_32BIT=1
-    #     $(conda_root)\Scripts\conda create -yq -n python$(python_version) python=$(python_version)
+    #     $(conda_root)\Scripts\conda create -yq -n python$(PYTHON_VERSION) python=$(PYTHON_VERSION)
     #   condition: eq(variables['python_arch'], 'x86')
-    #   displayName: 'Install Python $(python_version)'
+    #   displayName: 'Install Python $(PYTHON_VERSION)'
     - script: |
-        git clone https://github.com/NordicPlayground/vcpkg.git $(vcpkg_root)
-        $(vcpkg_root)\bootstrap-vcpkg.bat
+        git clone https://github.com/NordicPlayground/vcpkg.git $(VCPKG_ROOT)
+        $(VCPKG_ROOT)\bootstrap-vcpkg.bat
       displayName: 'Install vcpkg'
     - script: |
-        set PATH=$(vcpkg_root);%PATH%
+        set PATH=$(VCPKG_ROOT);%PATH%
         vcpkg install nrf-ble-driver:$(triplet)
-      env: {
-        VCPKG_ROOT: '$(vcpkg_root)',
-      }
       displayName: 'Install nrf-ble-driver'
     - script: |
-        # call $(conda_root)\Scripts\activate python$(python_version)
+        # call $(conda_root)\Scripts\activate python$(PYTHON_VERSION)
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Release -- -G "Visual Studio 15 2017 Win64"
-      env: {
-        VCPKG_ROOT: '$(vcpkg_root)',
-      }
       condition: eq(variables['python_arch'], 'x64')
       displayName: 'Build'
     - script: |
-        # call $(conda_root)\Scripts\activate python$(python_version)
+        # call $(conda_root)\Scripts\activate python$(PYTHON_VERSION)
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Release -- -G "Visual Studio 15 2017"
-      env: {
-        VCPKG_ROOT: '$(vcpkg_root)',
-      }
       condition: eq(variables['python_arch'], 'x86')
       displayName: 'Build'
     - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -213,7 +213,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls -1 ${pyroot}/libs/python*.lib`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G $(generator)
+        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "$(generator)"
       displayName: 'Build for python 2.7'
     - task: UsePythonVersion@0
       inputs:
@@ -227,7 +227,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls -1 ${pyroot}/libs/python*.lib`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G $(generator)
+        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "$(generator)"
       displayName: 'Build for python 3.5'
     - task: UsePythonVersion@0
       inputs:
@@ -241,7 +241,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls -1 ${pyroot}/libs/python*.lib`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G $(generator)
+        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "$(generator)"
       displayName: 'Build for python 3.6'
     - task: UsePythonVersion@0
       inputs:
@@ -255,7 +255,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls -1 ${pyroot}/libs/python*.lib`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G $(generator)
+        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "$(generator)"
       displayName: 'Build for python 3.7'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
     - script: |
         export PATH=$(conda_root)/envs/python$(python_version)/bin:$PATH
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Debug
+        python setup.py bdist_wheel --build-type Release
       env: {
         VCPKG_ROOT: '$(vcpkg_root)',
       }
@@ -119,7 +119,7 @@ jobs:
         export PATH=$(conda_root)/envs/python$(python_version)/bin:$PATH
         export PYTHON_VERSION=$(python_version)
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Debug -- -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
+        python setup.py bdist_wheel --build-type Release -- -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
       env: {
         VCPKG_ROOT: '$(Agent.HomeDirectory)/vcpkg',
       }
@@ -215,7 +215,7 @@ jobs:
     - script: |
         call $(conda_root)\Scripts\activate python$(python_version)
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Debug -- -G "Visual Studio 15 2017 Win64"
+        python setup.py bdist_wheel --build-type Release -- -G "Visual Studio 15 2017 Win64"
       env: {
         VCPKG_ROOT: '$(vcpkg_root)',
       }
@@ -224,7 +224,7 @@ jobs:
     - script: |
         call $(conda_root)\Scripts\activate python$(python_version)
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Debug -- -G "Visual Studio 15 2017"
+        python setup.py bdist_wheel --build-type Release -- -G "Visual Studio 15 2017"
       env: {
         VCPKG_ROOT: '$(vcpkg_root)',
       }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,7 +152,7 @@ jobs:
       condition: eq(variables['python_arch'], 'x64')
       displayName: 'Install Python $(python_version)'
     - script: |
-        set CONDA_FORCE_32BIT=1
+        call set CONDA_FORCE_32BIT=1
         $(conda_root)\Scripts\conda create -yq -n python$(python_version) python=$(python_version)
       condition: eq(variables['python_arch'], 'x86')
       displayName: 'Install Python $(python_version)'
@@ -177,9 +177,9 @@ jobs:
       condition: eq(variables['python_arch'], 'x64')
       displayName: 'Build'
     - script: |
-        set CONDA_FORCE_32BIT=1
+        call set CONDA_FORCE_32BIT=1
         call $(conda_root)\Scripts\activate python$(python_version)
-        set
+        call set
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Debug
       env: {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -211,7 +211,7 @@ jobs:
         pyroot=`dirname ${pypath}`
         pyheader=`ls ${pyroot}/include/Python.h`
         pyincldir=`dirname ${pyheader}`
-        pylib=`ls -1 ${pyroot}/libs/python*.lib`
+        pylib=`ls ${pyroot}/libs/python27.lib`
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "$(generator)"
       displayName: 'Build for python 2.7'
@@ -225,7 +225,7 @@ jobs:
         pyroot=`dirname ${pypath}`
         pyheader=`ls ${pyroot}/include/Python.h`
         pyincldir=`dirname ${pyheader}`
-        pylib=`ls -1 ${pyroot}/libs/python*.lib`
+        pylib=`ls ${pyroot}/libs/python35.lib`
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "$(generator)"
       displayName: 'Build for python 3.5'
@@ -239,7 +239,7 @@ jobs:
         pyroot=`dirname ${pypath}`
         pyheader=`ls ${pyroot}/include/Python.h`
         pyincldir=`dirname ${pyheader}`
-        pylib=`ls -1 ${pyroot}/libs/python*.lib`
+        pylib=`ls ${pyroot}/libs/python36.lib`
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "$(generator)"
       displayName: 'Build for python 3.6'
@@ -253,7 +253,7 @@ jobs:
         pyroot=`dirname ${pypath}`
         pyheader=`ls ${pyroot}/include/Python.h`
         pyincldir=`dirname ${pyheader}`
-        pylib=`ls -1 ${pyroot}/libs/python*.lib`
+        pylib=`ls ${pyroot}/libs/python37.lib`
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "$(generator)"
       displayName: 'Build for python 3.7'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -184,9 +184,12 @@ jobs:
     - script: |
         choco install -y --x86 swig
         choco install -y miniconda3 --params="'/D:$(conda_root)'"
+      condition: neq(variables['python_version'], '2.7')
       displayName: 'Install toolchain on Windows'
     - script: |
-        choco install vcpython27
+        choco install -y --x86 swig
+        choco install -y miniconda3 --params="'/D:$(conda_root)'"
+        choco install -y vcpython27
       condition: eq(variables['python_version'], '2.7')
       displayName: 'Install toolchain on Windows for Python 2.7'
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,8 @@ jobs:
       vmImage: 'macos-10.13'
     steps:
     - script: |
-        sudo xcode-select -s /Applications/Xcode_10..app
+        ls /Applications
+        sudo xcode-select -s /Applications/Xcode_9.4.1.app
       displayName: 'Install toolchain'
     - script: |
         brew install gcc swig

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,9 +54,7 @@ jobs:
       }
       displayName: 'Build'
     - bash: |
-        ls
-        ls dist
-        cp -R dist/**/*.whl "$(Build.ArtifactStagingDirectory)"
+        cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
       displayName: 'Copy artifacts'
     - task: GitHubRelease@0
       inputs:
@@ -130,7 +128,7 @@ jobs:
     - bash: |
         ls
         ls dist
-        cp -R dist/**/*.whl "$(Build.ArtifactStagingDirectory)"
+        cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
       displayName: 'Copy artifacts'
     - task: GitHubRelease@0
       inputs:
@@ -231,7 +229,7 @@ jobs:
     - bash: |
         ls
         ls dist
-        cp -R dist/**/*.whl "$(Build.ArtifactStagingDirectory)"
+        cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
       displayName: 'Copy artifacts'
     - task: GitHubRelease@0
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -178,6 +178,7 @@ jobs:
       displayName: 'Build'
     - script: |
         call $(conda_root)\Scripts\activate python$(python_version)
+        set CXXFLAGS="-m32"
         set
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Debug -- -DCMAKE_GENERATOR_PLATFORM=x86

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -178,10 +178,9 @@ jobs:
       displayName: 'Build'
     - script: |
         call $(conda_root)\Scripts\activate python$(python_version)
-        set CXXFLAGS="-m32"
         set
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Debug
+        python setup.py bdist_wheel --build-type Debug -- -DCMAKE_CXX_FLAGS=-m32
       env: {
         VCPKG_ROOT: '$(vcpkg_root)',
       }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,7 +116,6 @@ jobs:
       }
       displayName: 'Install nrf-ble-driver'
     - script: |
-        export MACOSX_DEPLOYMENT_TARGET=10.10
         export PATH=$(conda_root)/envs/python$(python_version)/bin:$PATH
         export PYTHON_VERSION=$(python_version)
         pip install -r requirements-dev.txt
@@ -126,8 +125,6 @@ jobs:
       }
       displayName: 'Build'
     - bash: |
-        ls
-        ls dist
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
       displayName: 'Copy artifacts'
     - task: GitHubRelease@0
@@ -189,6 +186,10 @@ jobs:
         choco install -y miniconda3 --params="'/D:$(conda_root)'"
       displayName: 'Install toolchain on Windows'
     - script: |
+        choco install vcpython27
+      condition: eq(variables['python_version'], '2.7')
+      displayName: 'Install toolchain on Windows for Python 2.7'
+    - script: |
         $(conda_root)\Scripts\conda create -yq -n python$(python_version) python=$(python_version)
       condition: eq(variables['python_arch'], 'x64')
       displayName: 'Install Python $(python_version)'
@@ -210,7 +211,6 @@ jobs:
       displayName: 'Install nrf-ble-driver'
     - script: |
         call $(conda_root)\Scripts\activate python$(python_version)
-        pip install --upgrade pip
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Debug -- -G "Visual Studio 15 2017 Win64"
       env: {
@@ -220,7 +220,6 @@ jobs:
       displayName: 'Build'
     - script: |
         call $(conda_root)\Scripts\activate python$(python_version)
-        pip install --upgrade pip
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Debug -- -G "Visual Studio 15 2017"
       env: {
@@ -229,8 +228,6 @@ jobs:
       condition: eq(variables['python_arch'], 'x86')
       displayName: 'Build'
     - bash: |
-        ls
-        ls dist
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
       displayName: 'Copy artifacts'
     - task: GitHubRelease@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,20 +90,24 @@ jobs:
     pool:
       vmImage: 'macos-10.13'
     steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '$(python_version)'
+        architecture: 'x64'
     - script: |
         ls /Applications
         sudo xcode-select -s /Applications/Xcode_10.1.app
       displayName: 'Install toolchain'
     - script: |
-        brew install gcc swig
+        brew install swig
       displayName: 'Install toolchain'
-    - script: |
-        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-$(conda_version).sh -O $(Agent.HomeDirectory)/miniconda.sh
-        bash $(Agent.HomeDirectory)/miniconda.sh -b -p $(conda_root)
-      displayName: 'Install conda'
-    - script: |
-        $(conda_root)/bin/conda create -yq -n python$(python_version) python=$(python_version)
-      displayName: 'Install Python $(python_version)'
+    # - script: |
+    #     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-$(conda_version).sh -O $(Agent.HomeDirectory)/miniconda.sh
+    #     bash $(Agent.HomeDirectory)/miniconda.sh -b -p $(conda_root)
+    #   displayName: 'Install conda'
+    # - script: |
+    #     $(conda_root)/bin/conda create -yq -n python$(python_version) python=$(python_version)
+    #   displayName: 'Install Python $(python_version)'
     - script: |
         git clone https://github.com/NordicPlayground/vcpkg.git $(vcpkg_root)
         $(vcpkg_root)/bootstrap-vcpkg.sh
@@ -116,8 +120,8 @@ jobs:
       }
       displayName: 'Install nrf-ble-driver'
     - script: |
-        export PATH=$(conda_root)/envs/python$(python_version)/bin:$PATH
-        export PYTHON_VERSION=$(python_version)
+        # export PATH=$(conda_root)/envs/python$(python_version)/bin:$PATH
+        # export PYTHON_VERSION=$(python_version)
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Release -- -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
       env: {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,6 +177,7 @@ jobs:
       condition: eq(variables['python_arch'], 'x64')
       displayName: 'Build'
     - script: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\tools\vsdevcmd.bat" x86
         call set CONDA_FORCE_32BIT=1
         call $(conda_root)\Scripts\activate python$(python_version)
         call set

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,17 +106,11 @@ jobs:
         export PATH=$VCPKG_ROOT:$PATH
         vcpkg install nrf-ble-driver:$(python_arch)-osx
       displayName: 'Install nrf-ble-driver'
-    # - task: UsePythonVersion@0
-    #   inputs:
-    #     versionSpec: '2.7'
-    #     architecture: '$(python_arch)'
     - bash: |
         wget https://www.python.org/ftp/python/2.7.16/python-2.7.16-macosx10.9.pkg
-        wget https://www.python.org/ftp/python/3.5.4/python-3.5.4-macosx10.6.pkg
         wget https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg
         wget https://www.python.org/ftp/python/3.7.3/python-3.7.3-macosx10.9.pkg
         sudo installer -pkg python-2.7.16-macosx10.9.pkg -target /
-        sudo installer -pkg python-3.5.4-macosx10.6.pkg -target /
         sudo installer -pkg python-3.6.8-macosx10.9.pkg -target /
         sudo installer -pkg python-3.7.3-macosx10.9.pkg -target /
       displayName: 'Install all pythons'
@@ -126,30 +120,12 @@ jobs:
         ${pypath} -m pip install -r requirements-dev.txt
         ${pypath} setup.py bdist_wheel --build-type RelWithDebInfo -- -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
       displayName: 'Build for python 2.7'
-    # - task: UsePythonVersion@0
-    #   inputs:
-    #     versionSpec: '3.5'
-    #     architecture: '$(python_arch)'
-    - bash: |
-        rm -rf _skbuild
-        pypath=`which python3.5`
-        ${pypath} -m pip install -r requirements-dev.txt
-        ${pypath} setup.py bdist_wheel --build-type RelWithDebInfo -- -DCMAKE_OSX_DEPLOYMENT_TARGET=10.6
-      displayName: 'Build for python 3.5'
-    # - task: UsePythonVersion@0
-    #   inputs:
-    #     versionSpec: '3.6'
-    #     architecture: '$(python_arch)'
     - bash: |
         rm -rf _skbuild
         pypath=`which python3.6`
         ${pypath} -m pip install -r requirements-dev.txt
         ${pypath} setup.py bdist_wheel --build-type RelWithDebInfo -- -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
       displayName: 'Build for python 3.6'
-    # - task: UsePythonVersion@0
-    #   inputs:
-    #     versionSpec: '3.7'
-    #     architecture: '$(python_arch)'
     - bash: |
         rm -rf _skbuild
         pypath=`which python3.7`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,8 +5,6 @@ jobs:
   # Linux
   - job: Linux
     variables:
-      # conda_version: 'Linux-x86_64'
-      # conda_root: '$(Agent.HomeDirectory)/miniconda3'
       VCPKG_ROOT: '$(Agent.HomeDirectory)/vcpkg'
       python_arch: 'x64'
       triplet: 'x64-linux'
@@ -46,7 +44,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DPYTHON_INCLUDE_DIR=${pyincldir}
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
       displayName: 'Build'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
@@ -67,8 +65,6 @@ jobs:
   # macOS
   - job: macOS
     variables:
-      # conda_version: 'MacOSX-x86_64'
-      # conda_root: '$(Agent.HomeDirectory)/miniconda3'
       VCPKG_ROOT: '$(Agent.HomeDirectory)/vcpkg'
       python_arch: 'x64'
       triplet: 'x64-osx'
@@ -89,16 +85,6 @@ jobs:
       inputs:
         versionSpec: '$(PYTHON_VERSION)'
         architecture: 'x64'
-    # - script: |
-    #     python_path=`which python`
-    #     python_dir=`dirname python`
-    #     python_incl=${python_dir}/include/python$(PYTHON_VERSION)
-    #     python_lib=
-    #     which pip
-    #     DYLD_PRINT_LIBRARIES=1 python --version
-    #     pip --version
-    #     ls "/Users/vsts/hostedtoolcache/Python$(PYTHON_VERSION).*/x64/include/python2.7"
-    #   displayName: 'Dig python'
     - script: |
         ls /Applications
         sudo xcode-select -s /Applications/Xcode_10.1.app
@@ -121,7 +107,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
       displayName: 'Build'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
@@ -141,7 +127,6 @@ jobs:
   # Windows
   - job: Windows
     variables:
-      # conda_root: '$(Agent.HomeDirectory)\miniconda3'
       VCPKG_ROOT: '$(Agent.HomeDirectory)\vcpkg'
     strategy:
       matrix:
@@ -199,6 +184,7 @@ jobs:
     - bash: |
         pypath=`which python`
         pyroot=`dirname ${pypath}`
+        find ${pyroot}
         pyheader=`ls ${pyroot}/include/python*/Python.h`
         pyincldir=`dirname ${pyheader}`
         pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
@@ -209,6 +195,7 @@ jobs:
     - bash: |
         pypath=`which python`
         pyroot=`dirname ${pypath}`
+        find ${pyroot}
         pyheader=`ls ${pyroot}/include/python*/Python.h`
         pyincldir=`dirname ${pyheader}`
         pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,6 +54,8 @@ jobs:
       }
       displayName: 'Build'
     - bash: |
+        ls
+        ls dist
         cp -R dist/**/*.whl "$(Build.ArtifactStagingDirectory)"
       displayName: 'Copy artifacts'
     - task: GitHubRelease@0
@@ -126,6 +128,8 @@ jobs:
       }
       displayName: 'Build'
     - bash: |
+        ls
+        ls dist
         cp -R dist/**/*.whl "$(Build.ArtifactStagingDirectory)"
       displayName: 'Copy artifacts'
     - task: GitHubRelease@0
@@ -225,6 +229,8 @@ jobs:
       condition: eq(variables['python_arch'], 'x86')
       displayName: 'Build'
     - bash: |
+        ls
+        ls dist
         cp -R dist/**/*.whl "$(Build.ArtifactStagingDirectory)"
       displayName: 'Copy artifacts'
     - task: GitHubRelease@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,7 @@ jobs:
       vmImage: 'macos-10.13'
     steps:
     - script: |
-        sudo xcode-select -s /Applications/Xcode_10.1.app
+        sudo xcode-select -s /Applications/Xcode_10..app
       displayName: 'Install toolchain'
     - script: |
         brew install gcc swig

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -164,21 +164,20 @@ jobs:
     - script: |
         call $(conda_root)\Scripts\activate python$(python_version)
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Debug
+        python setup.py bdist_wheel --build-type Debug -- -G "Visual Studio 15 2017 Win64"
       env: {
         VCPKG_ROOT: '$(vcpkg_root)',
       }
       condition: eq(variables['python_arch'], 'x64')
       displayName: 'Build'
     - script: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\tools\vsdevcmd.bat" -vcvars_ver=14.0  -arch=x86
         call set CONDA_FORCE_32BIT=1
         call $(conda_root)\Scripts\activate python$(python_version)
         call set
         python --version
         python version.py
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Debug
+        python setup.py bdist_wheel --build-type Debug -- -G "Visual Studio 15 2017"
       env: {
         VCPKG_ROOT: '$(vcpkg_root)',
       }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,7 @@ jobs:
       vmImage: 'macos-10.13'
     steps:
     - script: |
-        xcode-select -s /Applications/Xcode_10.1.app
+        sudo xcode-select -s /Applications/Xcode_10.1.app
       displayName: 'Install toolchain'
     - script: |
         brew install gcc swig

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,36 +2,24 @@ trigger:
 - test-azure
 
 jobs:
+  # Linux
   - job: Linux_Build
     variables:
-      conda_version: 'MacOSX-x86_64'
+      conda_version: 'Linux-x86_64'
       conda_root: '$(Agent.HomeDirectory)/miniconda3'
       vcpkg_root: '$(Agent.HomeDirectory)/vcpkg'
       python_arch: 'x64'
       triplet: 'x64-linux'
     strategy:
       matrix:
-        # linux_python_27:
-        #   image_name: 'ubuntu-16.04'
-        #   python_version: 2.7
-        #   python_arch: 'x64'
-        #   conda_version: 'Linux-x86_64'
-        #   triplet: 'x64-linux'
-        # linux_python_35:
-        #   image_name: 'ubuntu-16.04'
-        #   python_version: 3.5
-        #   python_arch: 'x64'
-        #   conda_version: 'Linux-x86_64'
-        #   triplet: 'x64-linux'
+        linux_python_27:
+          python_version: 2.7
+        linux_python_35:
+          python_version: 3.5
         linux_python_36:
           python_version: 3.6
-          conda_version: 'Linux-x86_64'
-        # linux_python_37:
-        #   image_name: 'ubuntu-16.04'
-        #   python_version: 3.7
-        #   python_arch: 'x64'
-        #   conda_version: 'Linux-x86_64'
-        #   triplet: 'x64-linux'
+        linux_python_37:
+          python_version: 3.7
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
@@ -72,12 +60,18 @@ jobs:
       conda_version: 'MacOSX-x86_64'
       conda_root: '$(Agent.HomeDirectory)/miniconda3'
       vcpkg_root: '$(Agent.HomeDirectory)/vcpkg'
+      python_arch: 'x64'
+      triplet: 'x64-osx'
     strategy:
       matrix:
+        mac_python_27:
+          python_version: 2.7
+        mac_python_35:
+          python_version: 3.5
         mac_python_36:
           python_version: 3.6
-          python_arch: 'x64'
-          triplet: 'x64-osx'
+        mac_python_37:
+          python_version: 3.7
     pool:
       vmImage: 'macos-10.13'
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -205,6 +205,7 @@ jobs:
     steps:
     - script: |
         choco install -y --x86 swig
+        choco install -y vcpython27
       displayName: 'Install toolchain on Windows'
     - script: |
         git clone https://github.com/NordicPlayground/vcpkg.git $(VCPKG_ROOT)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,7 +177,7 @@ jobs:
       condition: eq(variables['python_arch'], 'x64')
       displayName: 'Build'
     - script: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\tools\vsdevcmd.bat" x86
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\tools\vsdevcmd.bat" -vcvars_ver=14.0  -arch=x86
         call set CONDA_FORCE_32BIT=1
         call $(conda_root)\Scripts\activate python$(python_version)
         call set

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,6 +182,7 @@ jobs:
         call $(conda_root)\Scripts\activate python$(python_version)
         call set
         python --version
+        python version.py
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Debug
       env: {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,10 +177,11 @@ jobs:
       condition: eq(variables['python_arch'], 'x64')
       displayName: 'Build'
     - script: |
+        set CONDA_FORCE_32BIT=1
         call $(conda_root)\Scripts\activate python$(python_version)
         set
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Debug -- -DCMAKE_CXX_FLAGS=-m32
+        python setup.py bdist_wheel --build-type Debug
       env: {
         VCPKG_ROOT: '$(vcpkg_root)',
       }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,7 @@ jobs:
       vmImage: 'macos-10.13'
     steps:
     - script: |
-        xcode-select /Applications/Xcode_10.1.app
+        xcode-select -s /Applications/Xcode_10.1.app
       displayName: 'Install toolchain'
     - script: |
         brew install gcc swig

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -181,7 +181,7 @@ jobs:
         set CXXFLAGS="-m32"
         set
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Debug -- -DCMAKE_GENERATOR_PLATFORM=x86
+        python setup.py bdist_wheel --build-type Debug
       env: {
         VCPKG_ROOT: '$(vcpkg_root)',
       }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,17 +7,6 @@ jobs:
     variables:
       VCPKG_ROOT: '$(Agent.HomeDirectory)/vcpkg'
       python_arch: 'x64'
-      triplet: 'x64-linux'
-    strategy:
-      matrix:
-        linux_python_27:
-          PYTHON_VERSION: 2.7
-        linux_python_35:
-          PYTHON_VERSION: 3.5
-        linux_python_36:
-          PYTHON_VERSION: 3.6
-        linux_python_37:
-          PYTHON_VERSION: 3.7
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
@@ -25,19 +14,20 @@ jobs:
         sudo apt-get update
         sudo apt-get install ninja-build swig libudev-dev
       displayName: 'Install toolchain'
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '$(PYTHON_VERSION)'
-        architecture: 'x64'
     - script: |
         git clone https://github.com/NordicPlayground/vcpkg.git $(VCPKG_ROOT)
         $(VCPKG_ROOT)/bootstrap-vcpkg.sh
       displayName: 'Install vcpkg'
     - script: |
         export PATH=$VCPKG_ROOT:$PATH
-        vcpkg install nrf-ble-driver:$(triplet)
+        vcpkg install nrf-ble-driver:$(python_arch)-linux
       displayName: 'Install nrf-ble-driver'
-    - script: |
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '2.7'
+        architecture: '$(python_arch)'
+    - bash: |
+        rm -rf _skbuild
         pypath=`which python`
         pyroot=`dirname ${pypath}`
         pyheader=`ls ${pyroot}/include/python*/Python.h`
@@ -45,7 +35,49 @@ jobs:
         pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
-      displayName: 'Build'
+      displayName: 'Build for python 2.7'
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.5'
+        architecture: '$(python_arch)'
+    - bash: |
+        rm -rf _skbuild
+        pypath=`which python`
+        pyroot=`dirname ${pypath}`
+        pyheader=`ls ${pyroot}/include/python*/Python.h`
+        pyincldir=`dirname ${pyheader}`
+        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
+        pip install -r requirements-dev.txt
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
+      displayName: 'Build for python 3.5'
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.6'
+        architecture: '$(python_arch)'
+    - bash: |
+        rm -rf _skbuild
+        pypath=`which python`
+        pyroot=`dirname ${pypath}`
+        pyheader=`ls ${pyroot}/include/python*/Python.h`
+        pyincldir=`dirname ${pyheader}`
+        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
+        pip install -r requirements-dev.txt
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
+      displayName: 'Build for python 3.6'
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.7'
+        architecture: '$(python_arch)'
+    - bash: |
+        rm -rf _skbuild
+        pypath=`which python`
+        pyroot=`dirname ${pypath}`
+        pyheader=`ls ${pyroot}/include/python*/Python.h`
+        pyincldir=`dirname ${pyheader}`
+        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
+        pip install -r requirements-dev.txt
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
+      displayName: 'Build for python 3.7'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
       displayName: 'Copy artifacts'
@@ -67,24 +99,9 @@ jobs:
     variables:
       VCPKG_ROOT: '$(Agent.HomeDirectory)/vcpkg'
       python_arch: 'x64'
-      triplet: 'x64-osx'
-    strategy:
-      matrix:
-        mac_python_27:
-          PYTHON_VERSION: 2.7
-        mac_python_35:
-          PYTHON_VERSION: 3.5
-        mac_python_36:
-          PYTHON_VERSION: 3.6
-        mac_python_37:
-          PYTHON_VERSION: 3.7
     pool:
       vmImage: 'macos-10.13'
     steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '$(PYTHON_VERSION)'
-        architecture: 'x64'
     - script: |
         ls /Applications
         sudo xcode-select -s /Applications/Xcode_10.1.app
@@ -98,9 +115,14 @@ jobs:
       displayName: 'Install vcpkg'
     - script: |
         export PATH=$VCPKG_ROOT:$PATH
-        vcpkg install nrf-ble-driver:$(triplet)
+        vcpkg install nrf-ble-driver:$(python_arch)-osx
       displayName: 'Install nrf-ble-driver'
-    - script: |
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '2.7'
+        architecture: '$(python_arch)'
+    - bash: |
+        rm -rf _skbuild
         pypath=`which python`
         pyroot=`dirname ${pypath}`
         pyheader=`ls ${pyroot}/include/python*/Python.h`
@@ -108,7 +130,49 @@ jobs:
         pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
-      displayName: 'Build'
+      displayName: 'Build for python 2.7'
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.5'
+        architecture: '$(python_arch)'
+    - bash: |
+        rm -rf _skbuild
+        pypath=`which python`
+        pyroot=`dirname ${pypath}`
+        pyheader=`ls ${pyroot}/include/python*/Python.h`
+        pyincldir=`dirname ${pyheader}`
+        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
+        pip install -r requirements-dev.txt
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
+      displayName: 'Build for python 3.5'
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.6'
+        architecture: '$(python_arch)'
+    - bash: |
+        rm -rf _skbuild
+        pypath=`which python`
+        pyroot=`dirname ${pypath}`
+        pyheader=`ls ${pyroot}/include/python*/Python.h`
+        pyincldir=`dirname ${pyheader}`
+        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
+        pip install -r requirements-dev.txt
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
+      displayName: 'Build for python 3.6'
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.7'
+        architecture: '$(python_arch)'
+    - bash: |
+        rm -rf _skbuild
+        pypath=`which python`
+        pyroot=`dirname ${pypath}`
+        pyheader=`ls ${pyroot}/include/python*/Python.h`
+        pyincldir=`dirname ${pyheader}`
+        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
+        pip install -r requirements-dev.txt
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
+      displayName: 'Build for python 3.7'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
       displayName: 'Copy artifacts'
@@ -130,48 +194,17 @@ jobs:
       VCPKG_ROOT: '$(Agent.HomeDirectory)\vcpkg'
     strategy:
       matrix:
-        win64_python_27:
-          PYTHON_VERSION: 2.7
+        win64:
           python_arch: 'x64'
-          triplet: 'x64-windows'
-        win64_python_35:
-          PYTHON_VERSION: 3.5
-          python_arch: 'x64'
-          triplet: 'x64-windows'
-        win64_python_36:
-          PYTHON_VERSION: 3.6
-          python_arch: 'x64'
-          triplet: 'x64-windows'
-        win64_python_37:
-          PYTHON_VERSION: 3.7
-          python_arch: 'x64'
-          triplet: 'x64-windows'
-        win32_python_27:
-          PYTHON_VERSION: 2.7
+          generator: 'Visual Studio 15 2017 Win64'
+        win32:
           python_arch: 'x86'
-          triplet: 'x86-windows'
-        win32_python_35:
-          PYTHON_VERSION: 3.5
-          python_arch: 'x86'
-          triplet: 'x86-windows'
-        win32_python_36:
-          PYTHON_VERSION: 3.6
-          python_arch: 'x86'
-          triplet: 'x86-windows'
-        win32_python_37:
-          PYTHON_VERSION: 3.7
-          python_arch: 'x86'
-          triplet: 'x86-windows'
+          generator: 'Visual Studio 15 2017'
     pool:
       vmImage: 'vs2017-win2016'
     steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '$(PYTHON_VERSION)'
-        architecture: '$(python_arch)'
     - script: |
         choco install -y --x86 swig
-      # condition: ne(variables['PYTHON_VERSION'], '2.7')
       displayName: 'Install toolchain on Windows'
     - script: |
         git clone https://github.com/NordicPlayground/vcpkg.git $(VCPKG_ROOT)
@@ -179,28 +212,64 @@ jobs:
       displayName: 'Install vcpkg'
     - script: |
         set PATH=$(VCPKG_ROOT);%PATH%
-        vcpkg install nrf-ble-driver:$(triplet)
+        vcpkg install nrf-ble-driver:$(python_arch)-windows
       displayName: 'Install nrf-ble-driver'
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '2.7'
+        architecture: '$(python_arch)'
     - bash: |
+        rm -rf _skbuild
         pypath=`which python`
         pyroot=`dirname ${pypath}`
         pyheader=`ls ${pyroot}/include/Python.h`
         pyincldir=`dirname ${pyheader}`
-        pylib=`ls ${pyroot}/libs/libpython*.a`
+        pylib=`ls -1 ${pyroot}/libs/python*.lib`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "Visual Studio 15 2017 Win64"
-      condition: eq(variables['python_arch'], 'x64')
-      displayName: 'Build'
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G $(generator)
+      displayName: 'Build for python 2.7'
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.5'
+        architecture: '$(python_arch)'
     - bash: |
+        rm -rf _skbuild
         pypath=`which python`
         pyroot=`dirname ${pypath}`
         pyheader=`ls ${pyroot}/include/Python.h`
         pyincldir=`dirname ${pyheader}`
-        pylib=`ls ${pyroot}/libs/libpython*.a`
+        pylib=`ls -1 ${pyroot}/libs/python*.lib`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "Visual Studio 15 2017"
-      condition: eq(variables['python_arch'], 'x86')
-      displayName: 'Build'
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G $(generator)
+      displayName: 'Build for python 3.5'
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.6'
+        architecture: '$(python_arch)'
+    - bash: |
+        rm -rf _skbuild
+        pypath=`which python`
+        pyroot=`dirname ${pypath}`
+        pyheader=`ls ${pyroot}/include/Python.h`
+        pyincldir=`dirname ${pyheader}`
+        pylib=`ls -1 ${pyroot}/libs/python*.lib`
+        pip install -r requirements-dev.txt
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G $(generator)
+      displayName: 'Build for python 3.6'
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.7'
+        architecture: '$(python_arch)'
+    - bash: |
+        rm -rf _skbuild
+        pypath=`which python`
+        pyroot=`dirname ${pypath}`
+        pyheader=`ls ${pyroot}/include/Python.h`
+        pyincldir=`dirname ${pyheader}`
+        pylib=`ls -1 ${pyroot}/libs/python*.lib`
+        pip install -r requirements-dev.txt
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G $(generator)
+      displayName: 'Build for python 3.7'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
       displayName: 'Copy artifacts'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
 
 jobs:
   # Linux
-  - job: Linux_Build
+  - job: Linux
     variables:
       # conda_version: 'Linux-x86_64'
       # conda_root: '$(Agent.HomeDirectory)/miniconda3'
@@ -74,7 +74,7 @@ jobs:
 
 
   # macOS
-  - job: macOS_Build
+  - job: macOS
     variables:
       # conda_version: 'MacOSX-x86_64'
       # conda_root: '$(Agent.HomeDirectory)/miniconda3'
@@ -111,10 +111,10 @@ jobs:
     - script: |
         ls /Applications
         sudo xcode-select -s /Applications/Xcode_10.1.app
-      displayName: 'Install toolchain'
+      displayName: 'Install XCode'
     - script: |
         brew install gcc swig
-      displayName: 'Install toolchain'
+      displayName: 'Install gcc and swig'
     # - script: |
     #     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-$(conda_version).sh -O $(Agent.HomeDirectory)/miniconda.sh
     #     bash $(Agent.HomeDirectory)/miniconda.sh -b -p $(conda_root)
@@ -131,8 +131,6 @@ jobs:
         vcpkg install nrf-ble-driver:$(triplet)
       displayName: 'Install nrf-ble-driver'
     - script: |
-        # export PATH=$(conda_root)/envs/python$(PYTHON_VERSION)/bin:$PATH
-        export
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Release -- -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
       displayName: 'Build'
@@ -152,7 +150,7 @@ jobs:
       condition: ne(variables['Build.Reason'], 'PullRequest')
 
   # Windows
-  - job: Windows_Build
+  - job: Windows
     variables:
       # conda_root: '$(Agent.HomeDirectory)\miniconda3'
       VCPKG_ROOT: '$(Agent.HomeDirectory)\vcpkg'
@@ -206,7 +204,6 @@ jobs:
     #   displayName: 'Dig python'
     - script: |
         choco install -y --x86 swig
-        # choco install -y miniconda3 --params="'/D:$(conda_root)'"
       # condition: ne(variables['PYTHON_VERSION'], '2.7')
       displayName: 'Install toolchain on Windows'
     # - script: |
@@ -233,13 +230,11 @@ jobs:
         vcpkg install nrf-ble-driver:$(triplet)
       displayName: 'Install nrf-ble-driver'
     - script: |
-        # call $(conda_root)\Scripts\activate python$(PYTHON_VERSION)
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Release -- -G "Visual Studio 15 2017 Win64"
       condition: eq(variables['python_arch'], 'x64')
       displayName: 'Build'
     - script: |
-        # call $(conda_root)\Scripts\activate python$(PYTHON_VERSION)
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Release -- -G "Visual Studio 15 2017"
       condition: eq(variables['python_arch'], 'x86')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,17 +135,17 @@ jobs:
     pool:
       vmImage: 'vs2017-win2016'
     steps:
-    - script: |
-        choco install -y --x86 swig
-        choco install -y --x86 ninja
-        choco install -y miniconda3 --params="'/D:$(conda_root)'"
-      condition: eq(variables['python_arch'], 'x86')
-      displayName: 'Install toolchain on Windows'
+    # - script: |
+    #     choco install -y --x86 swig
+    #     choco install -y --x86 ninja
+    #     choco install -y miniconda3 --params="'/D:$(conda_root)'"
+    #   condition: eq(variables['python_arch'], 'x86')
+    #   displayName: 'Install toolchain on Windows'
     - script: |
         choco install -y --x86 swig
         choco install -y ninja
         choco install -y miniconda3 --params="'/D:$(conda_root)'"
-      condition: eq(variables['python_arch'], 'x64')
+      # condition: eq(variables['python_arch'], 'x64')
       displayName: 'Install toolchain on Windows'
     - script: |
         $(conda_root)\Scripts\conda create -yq -n python$(python_version) python=$(python_version)
@@ -161,7 +161,6 @@ jobs:
         $(vcpkg_root)\bootstrap-vcpkg.bat
       displayName: 'Install vcpkg'
     - script: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\tools\vsdevcmd.bat" -vcvars_ver=14.0  -arch=$(python_arch)
         set PATH=$(vcpkg_root);%PATH%
         vcpkg install nrf-ble-driver:$(triplet)
       env: {
@@ -169,8 +168,6 @@ jobs:
       }
       displayName: 'Install nrf-ble-driver'
     - script: |
-        set PYTHON_VERSION=
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\tools\vsdevcmd.bat" -vcvars_ver=14.0  -arch=$(python_arch)
         call $(conda_root)\Scripts\activate python$(python_version)
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Debug
@@ -180,12 +177,7 @@ jobs:
       condition: eq(variables['python_arch'], 'x64')
       displayName: 'Build'
     - script: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\tools\vsdevcmd.bat" -vcvars_ver=14.0  -arch=$(python_arch)
         call $(conda_root)\Scripts\activate python$(python_version)
-        set
-        set PYTHON_VERSION=
-        set CMAKE_GENERATOR_PLATFORM=x86
-        set CONDA_FORCE_32BIT=1
         set
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Debug

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,8 +44,9 @@ jobs:
         pyroot=`dirname ${pypath}`
         pyheader=`ls ${pyroot}/include/python*/Python.h`
         pyincldir=`dirname ${pyheader}`
+        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir}
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DPYTHON_INCLUDE_DIR=${pyincldir}
       displayName: 'Build'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
@@ -118,8 +119,9 @@ jobs:
         pyroot=`dirname ${pypath}`
         pyheader=`ls ${pyroot}/include/python*/Python.h`
         pyincldir=`dirname ${pyheader}`
+        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
       displayName: 'Build'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
@@ -199,8 +201,9 @@ jobs:
         pyroot=`dirname ${pypath}`
         pyheader=`ls ${pyroot}/include/python*/Python.h`
         pyincldir=`dirname ${pyheader}`
+        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -G "Visual Studio 15 2017 Win64"
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "Visual Studio 15 2017 Win64"
       condition: eq(variables['python_arch'], 'x64')
       displayName: 'Build'
     - bash: |
@@ -208,8 +211,9 @@ jobs:
         pyroot=`dirname ${pypath}`
         pyheader=`ls ${pyroot}/include/python*/Python.h`
         pyincldir=`dirname ${pyheader}`
+        pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -G "Visual Studio 15 2017"
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "Visual Studio 15 2017"
       condition: eq(variables['python_arch'], 'x86')
       displayName: 'Build'
     - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,13 +27,23 @@ jobs:
         sudo apt-get update
         sudo apt-get install ninja-build swig libudev-dev
       displayName: 'Install toolchain'
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '$(python_version)'
+        architecture: 'x64'
     - script: |
-        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-$(conda_version).sh -O $(Agent.HomeDirectory)/miniconda.sh
-        bash $(Agent.HomeDirectory)/miniconda.sh -b -p $(conda_root)
-      displayName: 'Install conda'
-    - script: |
-        $(conda_root)/bin/conda create -yq -n python$(python_version) python=$(python_version)
-      displayName: 'Install Python $(python_version)'
+        which python
+        which pip
+        python --version
+        pip --version
+      displayName: 'Dig python'
+    # - script: |
+    #     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-$(conda_version).sh -O $(Agent.HomeDirectory)/miniconda.sh
+    #     bash $(Agent.HomeDirectory)/miniconda.sh -b -p $(conda_root)
+    #   displayName: 'Install conda'
+    # - script: |
+    #     $(conda_root)/bin/conda create -yq -n python$(python_version) python=$(python_version)
+    #   displayName: 'Install Python $(python_version)'
     - script: |
         git clone https://github.com/NordicPlayground/vcpkg.git $(vcpkg_root)
         $(vcpkg_root)/bootstrap-vcpkg.sh
@@ -46,7 +56,7 @@ jobs:
       }
       displayName: 'Install nrf-ble-driver'
     - script: |
-        export PATH=$(conda_root)/envs/python$(python_version)/bin:$PATH
+        # export PATH=$(conda_root)/envs/python$(python_version)/bin:$PATH
         pip install -r requirements-dev.txt
         python setup.py bdist_wheel --build-type Release
       env: {
@@ -94,6 +104,12 @@ jobs:
       inputs:
         versionSpec: '$(python_version)'
         architecture: 'x64'
+    - script: |
+        which python
+        which pip
+        DYLD_PRINT_LIBRARIES=1 python --version
+        pip --version
+      displayName: 'Dig python'
     - script: |
         ls /Applications
         sudo xcode-select -s /Applications/Xcode_10.1.app

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -184,7 +184,7 @@ jobs:
     - script: |
         choco install -y --x86 swig
         choco install -y miniconda3 --params="'/D:$(conda_root)'"
-      condition: neq(variables['python_version'], '2.7')
+      condition: ne(variables['python_version'], '2.7')
       displayName: 'Install toolchain on Windows'
     - script: |
         choco install -y --x86 swig

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,20 +31,6 @@ jobs:
       inputs:
         versionSpec: '$(PYTHON_VERSION)'
         architecture: 'x64'
-    # - script: |
-    #     which python
-    #     which pip
-    #     python --version
-    #     pip --version
-    #     find /opt/hostedtoolcache/Python
-    #   displayName: 'Dig python'
-    # - script: |
-    #     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-$(conda_version).sh -O $(Agent.HomeDirectory)/miniconda.sh
-    #     bash $(Agent.HomeDirectory)/miniconda.sh -b -p $(conda_root)
-    #   displayName: 'Install conda'
-    # - script: |
-    #     $(conda_root)/bin/conda create -yq -n python$(PYTHON_VERSION) python=$(PYTHON_VERSION)
-    #   displayName: 'Install Python $(PYTHON_VERSION)'
     - script: |
         git clone https://github.com/NordicPlayground/vcpkg.git $(VCPKG_ROOT)
         $(VCPKG_ROOT)/bootstrap-vcpkg.sh
@@ -54,8 +40,12 @@ jobs:
         vcpkg install nrf-ble-driver:$(triplet)
       displayName: 'Install nrf-ble-driver'
     - script: |
+        pypath=`which python`
+        pyroot=`dirname ${pypath}`
+        pyheader=`ls ${pyroot}/include/python*/Python.h`
+        pyincldir=`dirname ${pyheader}`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir}
       displayName: 'Build'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
@@ -115,13 +105,6 @@ jobs:
     - script: |
         brew install gcc swig
       displayName: 'Install gcc and swig'
-    # - script: |
-    #     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-$(conda_version).sh -O $(Agent.HomeDirectory)/miniconda.sh
-    #     bash $(Agent.HomeDirectory)/miniconda.sh -b -p $(conda_root)
-    #   displayName: 'Install conda'
-    # - script: |
-    #     $(conda_root)/bin/conda create -yq -n python$(PYTHON_VERSION) python=$(PYTHON_VERSION)
-    #   displayName: 'Install Python $(PYTHON_VERSION)'
     - script: |
         git clone https://github.com/NordicPlayground/vcpkg.git $(VCPKG_ROOT)
         $(VCPKG_ROOT)/bootstrap-vcpkg.sh
@@ -131,8 +114,12 @@ jobs:
         vcpkg install nrf-ble-driver:$(triplet)
       displayName: 'Install nrf-ble-driver'
     - script: |
+        pypath=`which python`
+        pyroot=`dirname ${pypath}`
+        pyheader=`ls ${pyroot}/include/python*/Python.h`
+        pyincldir=`dirname ${pyheader}`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
       displayName: 'Build'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
@@ -195,32 +182,10 @@ jobs:
       inputs:
         versionSpec: '$(PYTHON_VERSION)'
         architecture: '$(python_arch)'
-    # - bash: |
-    #     which python
-    #     which pip
-    #     python --version
-    #     pip --version
-    #     find /c/hostedtoolcache/Python
-    #   displayName: 'Dig python'
     - script: |
         choco install -y --x86 swig
       # condition: ne(variables['PYTHON_VERSION'], '2.7')
       displayName: 'Install toolchain on Windows'
-    # - script: |
-    #     choco install -y --x86 swig
-    #     # choco install -y miniconda3 --params="'/D:$(conda_root)'"
-    #     choco install -y vcpython27
-    #   condition: eq(variables['PYTHON_VERSION'], '2.7')
-    #   displayName: 'Install toolchain on Windows for Python 2.7'
-    # - script: |
-    #     $(conda_root)\Scripts\conda create -yq -n python$(PYTHON_VERSION) python=$(PYTHON_VERSION)
-    #   condition: eq(variables['python_arch'], 'x64')
-    #   displayName: 'Install Python $(PYTHON_VERSION)'
-    # - script: |
-    #     call set CONDA_FORCE_32BIT=1
-    #     $(conda_root)\Scripts\conda create -yq -n python$(PYTHON_VERSION) python=$(PYTHON_VERSION)
-    #   condition: eq(variables['python_arch'], 'x86')
-    #   displayName: 'Install Python $(PYTHON_VERSION)'
     - script: |
         git clone https://github.com/NordicPlayground/vcpkg.git $(VCPKG_ROOT)
         $(VCPKG_ROOT)\bootstrap-vcpkg.bat
@@ -229,14 +194,22 @@ jobs:
         set PATH=$(VCPKG_ROOT);%PATH%
         vcpkg install nrf-ble-driver:$(triplet)
       displayName: 'Install nrf-ble-driver'
-    - script: |
+    - bash: |
+        pypath=`which python`
+        pyroot=`dirname ${pypath}`
+        pyheader=`ls ${pyroot}/include/python*/Python.h`
+        pyincldir=`dirname ${pyheader}`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -G "Visual Studio 15 2017 Win64"
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -G "Visual Studio 15 2017 Win64"
       condition: eq(variables['python_arch'], 'x64')
       displayName: 'Build'
-    - script: |
+    - bash: |
+        pypath=`which python`
+        pyroot=`dirname ${pypath}`
+        pyheader=`ls ${pyroot}/include/python*/Python.h`
+        pyincldir=`dirname ${pyheader}`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -G "Visual Studio 15 2017"
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -G "Visual Studio 15 2017"
       condition: eq(variables['python_arch'], 'x86')
       displayName: 'Build'
     - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
+        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
       displayName: 'Build for python 2.7'
     - task: UsePythonVersion@0
       inputs:
@@ -48,7 +48,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
+        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
       displayName: 'Build for python 3.5'
     - task: UsePythonVersion@0
       inputs:
@@ -62,7 +62,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
+        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
       displayName: 'Build for python 3.6'
     - task: UsePythonVersion@0
       inputs:
@@ -76,7 +76,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
+        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib}
       displayName: 'Build for python 3.7'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
@@ -129,7 +129,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
+        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
       displayName: 'Build for python 2.7'
     - task: UsePythonVersion@0
       inputs:
@@ -143,7 +143,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
+        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
       displayName: 'Build for python 3.5'
     - task: UsePythonVersion@0
       inputs:
@@ -157,7 +157,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
+        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
       displayName: 'Build for python 3.6'
     - task: UsePythonVersion@0
       inputs:
@@ -171,7 +171,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls ${pyroot}/lib/python*/config*/libpython*.a`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
+        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13
       displayName: 'Build for python 3.7'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
@@ -227,7 +227,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls -1 ${pyroot}/libs/python*.lib`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G $(generator)
+        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G $(generator)
       displayName: 'Build for python 2.7'
     - task: UsePythonVersion@0
       inputs:
@@ -241,7 +241,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls -1 ${pyroot}/libs/python*.lib`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G $(generator)
+        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G $(generator)
       displayName: 'Build for python 3.5'
     - task: UsePythonVersion@0
       inputs:
@@ -255,7 +255,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls -1 ${pyroot}/libs/python*.lib`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G $(generator)
+        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G $(generator)
       displayName: 'Build for python 3.6'
     - task: UsePythonVersion@0
       inputs:
@@ -269,7 +269,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls -1 ${pyroot}/libs/python*.lib`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G $(generator)
+        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G $(generator)
       displayName: 'Build for python 3.7'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,21 @@ jobs:
         VCPKG_ROOT: '$(vcpkg_root)',
       }
       displayName: 'Build'
+    - bash: |
+        cp -R dist/**/*.whl "$(Build.ArtifactStagingDirectory)"
+      displayName: 'Copy artifacts'
+    - task: GitHubRelease@0
+      inputs:
+        gitHubConnection: 'waylandCI'
+        repositoryName: 'NordicSemiconductor/pc-ble-driver-py'
+        action: 'edit'
+        tagSource: 'Git tag'
+        tag: '$(Build.SourceBranchName)'
+        assetUploadMode: 'replace'
+        isDraft: 'true'
+        addChangeLog: 'false'
+      condition: ne(variables['Build.Reason'], 'PullRequest')
+
 
   # macOS
   - job: macOS_Build
@@ -110,6 +125,20 @@ jobs:
         VCPKG_ROOT: '$(Agent.HomeDirectory)/vcpkg',
       }
       displayName: 'Build'
+    - bash: |
+        cp -R dist/**/*.whl "$(Build.ArtifactStagingDirectory)"
+      displayName: 'Copy artifacts'
+    - task: GitHubRelease@0
+      inputs:
+        gitHubConnection: 'waylandCI'
+        repositoryName: 'NordicSemiconductor/pc-ble-driver-py'
+        action: 'edit'
+        tagSource: 'Git tag'
+        tag: '$(Build.SourceBranchName)'
+        assetUploadMode: 'replace'
+        isDraft: 'true'
+        addChangeLog: 'false'
+      condition: ne(variables['Build.Reason'], 'PullRequest')
 
   # Windows
   - job: Windows_Build
@@ -195,68 +224,20 @@ jobs:
       }
       condition: eq(variables['python_arch'], 'x86')
       displayName: 'Build'
-
-    # Build
-    # - script: |
-    #     export PATH=$VCPKG_ROOT:$PATH
-    #     echo $PATH
-    #     echo $VCPKG_ROOT
-    #     vcpkg list
-    #     python -V
-    #     p_v=`which python`
-    #     p_d=`dirname $p_v`
-    #     echo ls p_d
-    #     ls $p_d
-    #     echo ls p_d/bin
-    #     ls $p_d/bin
-    #     python-config --includes
-    #     pip install -r requirements-dev.txt
-    #     python setup.py bdist_wheel --build-type Debug
-    #   env: {
-    #     VCPKG_ROOT: '$(Agent.HomeDirectory)/vcpkg',
-    #   }
-    #   condition: contains(variables['image_name'], 'ubuntu')
-    #   displayName: 'Build'
-    # - script: |
-    #     export PATH=$VCPKG_ROOT:$PATH
-    #     echo $PATH
-    #     echo $VCPKG_ROOT
-    #     vcpkg list
-    #     python -V
-    #     pip install -r requirements-dev.txt
-    #     python setup.py bdist_wheel --build-type Debug
-    #   env: {
-    #     VCPKG_ROOT: '$(Agent.HomeDirectory)/vcpkg',
-    #   }
-    #   condition: contains(variables['image_name'], 'mac')
-    #   displayName: 'Build'
-    # - script: |
-    #     set PATH=%VCPKG_ROOT%;%PATH%
-    #     echo %PATH%
-    #     echo %VCPKG_ROOT%
-    #     vcpkg list
-    #     python -V
-    #     pip install -r requirements-dev.txt
-    #     python setup.py bdist_wheel --build-type Debug
-    #   env: {
-    #     VCPKG_ROOT: '$(Agent.HomeDirectory)\vcpkg',
-    #   }
-    #   condition: contains(variables['image_name'], 'win')
-    #   displayName: 'Build'
-    # - bash: |
-    #     cp -R build/stage/**/*.tar.gz "$(Build.ArtifactStagingDirectory)"
-    #   displayName: 'Copy artifacts'
-    # - task: GitHubRelease@0
-    #   inputs:
-    #     gitHubConnection: 'waylandCI'
-    #     repositoryName: 'NordicSemiconductor/pc-nrfjprog-js'
-    #     action: 'edit'
-    #     tagSource: 'Git tag'
-    #     tag: '$(Build.SourceBranchName)'
-    #     assetUploadMode: 'replace'
-    #     isDraft: 'true'
-    #     addChangeLog: 'false'
-    #   condition: ne(variables['Build.Reason'], 'PullRequest')
+    - bash: |
+        cp -R dist/**/*.whl "$(Build.ArtifactStagingDirectory)"
+      displayName: 'Copy artifacts'
+    - task: GitHubRelease@0
+      inputs:
+        gitHubConnection: 'waylandCI'
+        repositoryName: 'NordicSemiconductor/pc-ble-driver-py'
+        action: 'edit'
+        tagSource: 'Git tag'
+        tag: '$(Build.SourceBranchName)'
+        assetUploadMode: 'replace'
+        isDraft: 'true'
+        addChangeLog: 'false'
+      condition: ne(variables['Build.Reason'], 'PullRequest')
 
   # - job: Test
   #   dependsOn: [

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,6 @@ setup(
         'pc_ble_driver_py.lib': ['*.pyd', '*.dll', '*.txt','*.so','*.dylib'],
         'pc_ble_driver_py.hex': ['*.hex'],
         'pc_ble_driver_py.hex.sd_api_v2': ['*.hex'],
-        'pc_ble_driver_py.hex.sd_api_v5': ['*.hex'],
+        'pc_ble_driver_py.hex.sd_api_v5': ['*.hex']
     }
 )

--- a/version.py
+++ b/version.py
@@ -1,0 +1,2 @@
+import platform
+print(platform.architecture())

--- a/version.py
+++ b/version.py
@@ -1,2 +1,0 @@
-import platform
-print(platform.architecture())


### PR DESCRIPTION
This PR adds support for building on Azure Pipelines.
The python extension module is built on Linux/macOS/Win32/Win64 hosted agents against Python 2.7/3.5/3.6 and 3.7.
The Linux builds use miniconda Python distribution, which is a workaround until the hosted Python is not built with `--enable-shared` option. Windows and macOS builds are using the hosted Python environments.
