### PR TITLE
Fix/serialport name mac os

### DIFF
--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -1265,8 +1265,18 @@ class SerialPortDescriptor(object):
 
     @classmethod
     def from_c(cls, org):
+        # Workaround to change from /dev/cu.X to /dev/tty.X
+        # tty.X is preferred because other products used that
+        # as an identifier for development kits serial ports
+        port = None
+
+        if not org.port == None and sys.platform == 'darwin':
+            port = org.port.replace("/cu", "/tty")
+        else:
+            port = org.port
+
         return cls(
-            port=org.port,
+            port=port,
             manufacturer=org.manufacturer,
             serial_number=org.serialNumber,
             pnp_id=org.pnpId,

--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -1266,7 +1266,7 @@ class SerialPortDescriptor(object):
     @classmethod
     def from_c(cls, org):
         # Workaround to change from /dev/cu.X to /dev/tty.X
-        # tty.X is preferred because other products used that
+        # tty.X is preferred because other products use that
         # as an identifier for development kits serial ports
         port = None
 

--- a/tests/test_programming.py
+++ b/tests/test_programming.py
@@ -72,7 +72,7 @@ class ProgramAdapter(unittest.TestCase):
         found_ports = map(lambda port: port.port, serial_ports)
 
         for serial_port in settings.serial_ports:
-            self.assertIn(serial_port, found_ports)
+            self.assertIn(serial_port.port, found_ports)
 
         for serial_port in serial_ports:
             if serial_port.port in settings.serial_ports:

--- a/tests/test_programming.py
+++ b/tests/test_programming.py
@@ -65,14 +65,14 @@ class ProgramAdapter(unittest.TestCase):
     def test_programming(self):
         settings = Settings.current()
 
-        serial_ports = BLEDriver.enum_serial_ports()
+        serial_ports = [port for port in BLEDriver.enum_serial_ports()]
 
         # Check that from enumeration matches
         # kits provided from settings
         found_ports = map(lambda port: port.port, serial_ports)
 
         for serial_port in settings.serial_ports:
-            self.assertIn(serial_port.port, found_ports)
+            self.assertIn(serial_port, found_ports)
 
         for serial_port in serial_ports:
             if serial_port.port in settings.serial_ports:

--- a/tests/test_programming.py
+++ b/tests/test_programming.py
@@ -67,8 +67,8 @@ class ProgramAdapter(unittest.TestCase):
 
         serial_ports = BLEDriver.enum_serial_ports()
 
-        # Check that number of kits from enumeration matches
-        # the number of kits provided from settings
+        # Check that from enumeration matches
+        # kits provided from settings
         self.assertTrue(len(serial_ports) >= len(settings.serial_ports))
         found_ports = map(lambda port: port.port, serial_ports)
 
@@ -78,7 +78,7 @@ class ProgramAdapter(unittest.TestCase):
         for serial_port in serial_ports:
             if serial_port.port in settings.serial_ports:
                 serial_number = serial_port.serial_number
-                logger.info("#%s deleting connectivity", serial_number)
+                logger.info("%s/%s deleting existing firmware", serial_port.port, serial_number)
 
                 flasher = Flasher(serial_port=serial_port.port)
                 flasher.erase()
@@ -91,6 +91,7 @@ class ProgramAdapter(unittest.TestCase):
                 )
 
                 flasher.fw_flash()
+                logger.info("%s/%s programmed", serial_port.port, serial_number)
 
                 self.assertTrue(
                     flasher.fw_check(),
@@ -101,7 +102,7 @@ class ProgramAdapter(unittest.TestCase):
 
                 flasher.reset()
 
-                logger.info("#%s programmed successfully", serial_number)
+                logger.info("%s/%s programmed successfully", serial_port.port, serial_number)
 
     def tearDown(self):
         pass

--- a/tests/test_programming.py
+++ b/tests/test_programming.py
@@ -69,7 +69,6 @@ class ProgramAdapter(unittest.TestCase):
 
         # Check that from enumeration matches
         # kits provided from settings
-        self.assertTrue(len(serial_ports) >= len(settings.serial_ports))
         found_ports = map(lambda port: port.port, serial_ports)
 
         for serial_port in settings.serial_ports:

--- a/tests/test_programming.py
+++ b/tests/test_programming.py
@@ -67,6 +67,10 @@ class ProgramAdapter(unittest.TestCase):
 
         serial_ports = BLEDriver.enum_serial_ports()
 
+        # Check that number of kits from enumeration matches
+        # the number of kits provided from settings
+        self.assertEqual(len(serial_ports), len(settings.serial_ports))
+
         for serial_port in serial_ports:
             if serial_port.port in settings.serial_ports:
                 serial_number = serial_port.serial_number

--- a/tests/test_programming.py
+++ b/tests/test_programming.py
@@ -69,7 +69,11 @@ class ProgramAdapter(unittest.TestCase):
 
         # Check that number of kits from enumeration matches
         # the number of kits provided from settings
-        self.assertEqual(len(serial_ports), len(settings.serial_ports))
+        self.assertTrue(len(serial_ports) >= len(settings.serial_ports))
+        found_ports = map(lambda port: port.port, serial_ports)
+
+        for serial_port in settings.serial_ports:
+            self.assertIn(serial_port, found_ports)
 
         for serial_port in serial_ports:
             if serial_port.port in settings.serial_ports:


### PR DESCRIPTION
* Rename from /dev/cu.X to /dev/tty.X on macOS to align with other tools
* Check serial port count provided match number of devices found