### PR TITLE
Add default args for keys params in ble_gap_sec_params_reply

### DIFF
--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -1784,7 +1784,7 @@ class BLEDriver(object):
     @NordicSemiErrorCheck
     @wrapt.synchronized(api_lock)
     def ble_gap_sec_params_reply(
-        self, conn_handle, sec_status, sec_params, own_keys, peer_keys
+        self, conn_handle, sec_status, sec_params, own_keys=None, peer_keys=None
     ):
         assert isinstance(sec_status, BLEGapSecStatus), "Invalid argument type"
         assert isinstance(


### PR DESCRIPTION
`ble_gap_sec_params_reply()` is used without  `own_keys` or `peer_keys` parameters in `ble_adapter.py` which currently breaks `authenticate()` function.

See https://github.com/NordicSemiconductor/pc-ble-driver-py/blob/master/pc_ble_driver_py/ble_adapter.py#L532