### PR TITLE
Fix setup.py find_packages usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ def find_version(*file_paths):
 
     raise RuntimeError("Unable to find version string.")
 
-packages = find_packages(exclude=["tests.*"])
+packages = find_packages(exclude=["tests*"])
 
 setup(
     name='pc_ble_driver_py',


### PR DESCRIPTION
* find_packages filter uses fnmatchcase, thus it cannot
  utilize regexp patterns. This caused 'tests' to appear
  in package, which broke dill usage on all projects that
  use pc-ble-driver-py:

```
  ...
  File "path-to-site-packages/dill/_dill.py", line 474, in find_class
    return StockUnpickler.find_class(self, module, name)
  File "path-to-site-packages/tests/__init__.py", line 4, in <module>
    from driver_setup import Settings
  ModuleNotFoundError: No module named 'driver_setup'
```