### PR TITLE
Remove references to BLE_EVT_DATA_LENGTH_CHANGED

### DIFF
--- a/pc_ble_driver_py/ble_adapter.py
+++ b/pc_ble_driver_py/ble_adapter.py
@@ -553,10 +553,6 @@ class BLEAdapter(BLEDriverObserver):
         return result["conn_sec"]
 
     # ...............................................................................................
-    def on_evt_data_length_changed(self, ble_driver, **kwargs):
-        for i in self.evt_sync:
-            self.evt_sync[i].notify(evt=BLEEvtID.evt_data_length_changed, data=kwargs)
-
     def on_gap_evt_connected(
         self, ble_driver, conn_handle, peer_addr, role, conn_params
     ):

--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -131,7 +131,6 @@ class BLEEvtID(Enum):
 
     if nrf_sd_ble_api_ver == 2:
         evt_tx_complete = driver.BLE_EVT_TX_COMPLETE
-        evt_data_length_changed = driver.BLE_EVT_DATA_LENGTH_CHANGED
 
     if nrf_sd_ble_api_ver == 5:
         gatts_evt_exchange_mtu_request = driver.BLE_GATTS_EVT_EXCHANGE_MTU_REQUEST


### PR DESCRIPTION
BLE_EVT_DATA_LENGTH_CHANGED is only supported by SD API v3, which is no longer supported in ble-driver-py