### PR TITLE
Fix issue where last bytes of incoming SD API v2 events were lost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ foreach(SD_API_VER ${SD_API_VERS})
     message(STATUS "LINK_LIBRARIES are not ${LINK_LIBRARIES}")
 
     target_link_libraries(${PYTHON_MODULE_${SD_API_VER}} PRIVATE ${LINK_LIBRARIES})
+    target_compile_definitions(${PYTHON_MODULE_${SD_API_VER}} PRIVATE NRF_SD_BLE_API_VERSION=${SD_API_VER})
 
     get_target_property(CONNECTIVITY_SD_API_V${SD_API_VER}_PATH nrf::nrf_ble_driver_sd_api_v${SD_API_VER}_${NRF_BLE_DRIVER_LINKAGE_TYPE} INTERFACE_INCLUDE_DIRECTORIES)
     set(CONNECTIVITY_SD_API_V${SD_API_VER}_PATH ${CONNECTIVITY_SD_API_V${SD_API_VER}_PATH}/../../share/nrf-ble-driver/hex/sd_api_v${SD_API_VER})

--- a/swig/pc_ble_driver.i.in
+++ b/swig/pc_ble_driver.i.in
@@ -239,7 +239,7 @@ static void PythonEvtCallBack(adapter_t *adapter, ble_evt_t *ble_event)
     // this callback is complete. The event that is received in this function is allocated
     // on the stack of the function calling this function.
 
-#if SD_BLE_API_VERSION == 2
+#if NRF_SD_BLE_API_VERSION == 2
     copied_ble_event = (ble_evt_t*)malloc(sizeof(ble_evt_t));
     memcpy(copied_ble_event, ble_event, sizeof(ble_evt_t));
 #else


### PR DESCRIPTION
The problem was a missing build define resulting in SD API v2 events being parsed as SD API v5