### PR TITLE
s132v5_py3 fixes

### DIFF
--- a/pc_ble_driver_py/ble_adapter.py
+++ b/pc_ble_driver_py/ble_adapter.py
@@ -472,8 +472,8 @@ class BLEAdapter(BLEDriverObserver):
                 )
                 return
             except NordicSemiException as e:
-                # Retry if BLE_ERROR_NO_TX_PACKETS error code.
-                if "Error code: 12292" in e.message or "Error code: 12307" in e.message:
+                # Retry if NRF_ERROR_RESOURCES error code.
+                if "Error code: 19" in str(e):
                     self.evt_sync[conn_handle].wait(evt=tx_complete, timeout=1)
                 else:
                     raise e

--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -2264,7 +2264,6 @@ class BLEDriver(object):
 
             elif evt_id == BLEEvtID.gattc_evt_read_rsp:
                 read_rsp_evt = ble_event.evt.gattc_evt.params.read_rsp
-                logger.debug("GATTC: READ RSP")
                 for obs in self.observers:
                     obs.on_gattc_evt_read_rsp(
                         ble_driver=self,


### PR DESCRIPTION
* ble_driver: silence debug messages
* fix gattc_write retry
- SDv5 uses NRF_ERROR_RESOURCES (19) to indicate too many writes.
- e.message is invalid in Python3, use str(e) instead.

This PR is a replication of #95 for getting the changes into master.