### PR TITLE
Fix issue with vcpkg/cmake not supporting relwithdebinfo

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,7 +120,7 @@ jobs:
         pyincldir=`dirname ${pyheader}`
         pylib=`ls ${pyroot}/libs/python37.lib`
         pip install -r requirements-dev.txt
-        python setup.py bdist_wheel --build-type RelWithDebInfo -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "$(generator)"
+        python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "$(generator)"
       displayName: 'Build for python 3.7'
     - bash: |
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"


### PR DESCRIPTION
vcpkg/cmake does not support VC RelWithDebInfo 

This ticket describes the issue:
https://github.com/microsoft/vcpkg/issues/5621

This PR change the build type from RelWithDebInfo to Release, circumventing the issue.
