### PR TITLE
No need to return a map for devices, return a usable list

### DIFF
--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -1538,7 +1538,7 @@ class BLEDriver(object):
         dlen = driver.uint32_value(arr_len)
 
         descs = util.serial_port_desc_array_to_list(c_desc_arr, dlen)
-        return map(SerialPortDescriptor.from_c, descs)
+        return list(map(SerialPortDescriptor.from_c, descs))
 
     @NordicSemiErrorCheck
     @wrapt.synchronized(api_lock)


### PR DESCRIPTION
Device enumeration return a map object which is of no use for consumer.
This PR return the result of device enumeration as a list instead.