### PR TITLE
Print friendly error names in NordicSemiErrorCheck

### DIFF
--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -86,6 +86,12 @@ import pc_ble_driver_py.ble_driver_types as util
 from pc_ble_driver_py.exceptions import NordicSemiException
 
 
+NRF_ERRORS = { 
+    getattr(driver, name): name 
+    for name in dir(driver) if name.startswith('NRF_ERROR_')
+}
+
+
 def NordicSemiErrorCheck(wrapped=None, expected=driver.NRF_SUCCESS):
     if wrapped is None:
         return functools.partial(NordicSemiErrorCheck, expected=expected)
@@ -95,7 +101,9 @@ def NordicSemiErrorCheck(wrapped=None, expected=driver.NRF_SUCCESS):
         err_code = wrapped(*args, **kwargs)
         if err_code != expected:
             raise NordicSemiException(
-                "Failed to {}. Error code: {}".format(wrapped.__name__, err_code),
+                "Failed to {}. Error code: {}".format(
+                    wrapped.__name__, NRF_ERRORS.get(err_code, err_code)
+                ),
                 error_code=err_code,
             )
 


### PR DESCRIPTION
The `NordicSemiErrorCheck` decorator is used to catch errors from softdevice functions and convert them into python exceptions. 

Currently the error numbers are reported as raw integers which are not particularly developer friendly.

This PR automatically collects the list of defined error codes into a dictionary which is then used when creating an exception, so instead of looking like:
```
Exception in connect_and_discover:Failed to ble_gattc_prim_srvc_disc. Error code: 17
```
they now look like
```
Exception in connect_and_discover:Failed to ble_gattc_prim_srvc_disc. Error code: NRF_ERROR_BUSY

```