### PR TITLE
Use attribute handle to address attributes and on notification

### DIFF
--- a/pc_ble_driver_py/observers.py
+++ b/pc_ble_driver_py/observers.py
@@ -333,7 +333,10 @@ class BLEAdapterObserver(object):
     def on_indication_handle(self, ble_adapter, conn_handle, uuid, attr_handle, data):
         pass
 
-    def on_notification(self, ble_adapter, conn_handle, uuid, char_handle, data):
+    def on_notification(self, ble_adapter, conn_handle, uuid, data):
+    pass
+
+    def on_notification_handle(self, ble_adapter, conn_handle, uuid, attr_handle, data):
         pass
 
     def on_conn_param_update_request(self, ble_adapter, conn_handle, conn_params):

--- a/pc_ble_driver_py/observers.py
+++ b/pc_ble_driver_py/observers.py
@@ -327,7 +327,10 @@ class BLEAdapterObserver(object):
     def __init__(self, *args, **kwargs):
         super(BLEAdapterObserver, self).__init__()
 
-    def on_indication(self, ble_adapter, conn_handle, uuid, char_handle, data):
+    def on_indication(self, ble_adpater, conn_handle, uuid, data):
+    pass
+
+    def on_indication_handle(self, ble_adapter, conn_handle, uuid, attr_handle, data):
         pass
 
     def on_notification(self, ble_adapter, conn_handle, uuid, char_handle, data):

--- a/pc_ble_driver_py/observers.py
+++ b/pc_ble_driver_py/observers.py
@@ -327,10 +327,10 @@ class BLEAdapterObserver(object):
     def __init__(self, *args, **kwargs):
         super(BLEAdapterObserver, self).__init__()
 
-    def on_indication(self, ble_adapter, conn_handle, uuid, data):
+    def on_indication(self, ble_adapter, conn_handle, uuid, char_handle, data):
         pass
 
-    def on_notification(self, ble_adapter, conn_handle, uuid, data):
+    def on_notification(self, ble_adapter, conn_handle, uuid, char_handle, data):
         pass
 
     def on_conn_param_update_request(self, ble_adapter, conn_handle, conn_params):


### PR DESCRIPTION
This allows the caller to address attributes with duplicate UUIDs (Issue #132)
Also pass attribute handles in notification/indication event calls so the observer can differentiate attributes with duplicate UUIDs. This is a breaking change, but perhaps necessary to do at some point.