### PR TITLE
Fixed error handling for NRF_ERROR_RESOURCES

### DIFF
--- a/pc_ble_driver_py/ble_adapter.py
+++ b/pc_ble_driver_py/ble_adapter.py
@@ -488,7 +488,7 @@ class BLEAdapter(BLEDriverObserver):
                 return
             except NordicSemiException as e:
                 # Retry if NRF_ERROR_RESOURCES error code.
-                if "Error code: 19" in str(e):
+                if ("Error code: 19" in str(e)) or ("NRF_ERROR_RESOURCES" in str(e)):
                     self.evt_sync[conn_handle].wait(evt=tx_complete, timeout=1)
                 else:
                     raise e


### PR DESCRIPTION
Whenever a NRF_ERROR_RESOURCES was encountered, the error-handling code in the BLEAdapter was searching for the string "Error code: 19" even though this string is no longer contained within the exception. Because of this, these were never getting handled and the program simply crashed instead, including when using nrfutil's DFU functionality. I've fixed the code in question so it should be handling these errors correctly again.