### PR TITLE
Reorder tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,8 +28,9 @@ commands =
     {envpython} setup.py bdist_wheel --build-type {env:BUILD_TYPE:Release}
     {envpython} -m pip install --force --only-binary pc-ble-driver-py --find-links=dist --pre pc-ble-driver-py
     {envpython} tests/test_programming.py --port-a {env:PORT_A} --port-b {env:PORT_B} --log-level {env:LOG_LEVEL:debug} --driver-log-level {env:DRIVER_LOG_LEVEL:trace}
-    {envpython} tests/test_driver_open_close.py --port-a {env:PORT_A} --port-b {env:PORT_B} --log-level {env:LOG_LEVEL:debug} --driver-log-level {env:DRIVER_LOG_LEVEL:trace}
     {envpython} tests/test_ble_common_api.py --port-a {env:PORT_A} --port-b {env:PORT_B} --log-level {env:LOG_LEVEL:debug} --driver-log-level {env:DRIVER_LOG_LEVEL:trace}
     {envpython} tests/test_rssi.py --port-a {env:PORT_A} --port-b {env:PORT_B} --log-level {env:LOG_LEVEL:debug} --driver-log-level {env:DRIVER_LOG_LEVEL:trace}
     {envpython} tests/test_mtu.py --port-a {env:PORT_A} --port-b {env:PORT_B} --log-level {env:LOG_LEVEL:debug} --driver-log-level {env:DRIVER_LOG_LEVEL:trace}
     {envpython} tests/test_server_client.py --port-a {env:PORT_A} --port-b {env:PORT_B} --log-level {env:LOG_LEVEL:debug} --driver-log-level {env:DRIVER_LOG_LEVEL:trace}
+    {envpython} tests/test_driver_open_close.py --port-a {env:PORT_A} --port-b {env:PORT_B} --log-level {env:LOG_LEVEL:debug} --driver-log-level {env:DRIVER_LOG_LEVEL:trace}
+    


### PR DESCRIPTION
Move open_close test to the bottom ensure the other tests are run first. This is to mitigate an issue where open_close sometimes fails with seg_fault and stops further test execution.