### PR TITLE
Remove m from windows wheel name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,6 +157,7 @@ jobs:
         python setup.py bdist_wheel --build-type Release -- -DPYTHON_INCLUDE_DIR=${pyincldir} -DPYTHON_LIBRARY=${pylib} -G "$(generator)"
       displayName: 'Build for python $(python_version)'
     - bash: |
+        for f in dist/*; do mv "${f}" "${f/cp38m/cp38}"; done;
         cp -R dist/*.whl "$(Build.ArtifactStagingDirectory)"
       displayName: 'Copy artifacts'
     - task: GitHubRelease@0


### PR DESCRIPTION
This PR is due to fixing wheel name on windows by removing 'm' in the wheel file name.