### PR TITLE
setup.py: Fix the range of supported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
     ],
     keywords='nordic nrf51 nrf52 ble bluetooth softdevice serialization bindings pc-ble-driver pc-ble-driver-py '
              'pc_ble_driver pc_ble_driver_py',
-    python_requires=">=3.6, <=3.8",
+    python_requires=">=3.6, <3.9",
     install_requires=requirements,
     packages=packages,
     package_data={


### PR DESCRIPTION
The previous '<=3.8' matches 3.8.0 or smaller, instead of the whole 3.8
series as intended. Instead, replace with '<3.9' which will match the
whole of the 3.8 series.