### PR TITLE
Fixed __eq__ and __hash__ functions in BLEUUID.

### DIFF
--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -1089,10 +1089,11 @@ class BLEUUID(object):
     def __eq__(self, other):
         if not isinstance(other, BLEUUID):
             return False
-        return (self.value == other.value) and (self.base.base == other.base.base)
+        return (self.value == other.value) and (self.base.type == other.base.type) and \
+            (self.base.base is None or other.base.base is None or self.base.base == other.base.base)
 
     def __hash__(self):
-        return hash(self.value * sum(self.base.base))
+        return hash(self.value * (self.base.type or 1))
 
     @classmethod
     def from_c(cls, uuid):


### PR DESCRIPTION
When full UUID object (with UUIDBase) is used to write to a
characteristic (eg. Nordic UART), the returned UUID object from API (in
on_notification) is in shortened form, and does not contain the full
base UUID. However, it can safely be compared just by the 'type' field
and value.

Similarly, these objects could not be hashed, because self.base.base is
None, not list, and thus the __hash__ function fails inside
sum(self.base.base).

I am pretty sure this approach is correct, as when type is not None, it uniquely identifies the base. It seems to work with both standard services (tested with battery and firmware info) and vendor specific services and characteristics.

What I'm not sure is if self.base.type can ever be None; just to be sure, I included provision for that case and pu "or 1" into the __hash__ function.

This PR partially solves #38 in some cases, though you still need to use ble_vs_uuid_add() for the characteristic. This is actually the way I found it, as I called ble_vs_uuid_add() to register a characteristic UUID, and then used that to write. However, the notification on this characteristic (in my case containing answer to previous query) did not match the UUID object supplied by me on the write.