### PR TITLE
Duplicate vs discovered services when calling adapter.service_discovery()

### DIFF
--- a/pc_ble_driver_py/ble_adapter.py
+++ b/pc_ble_driver_py/ble_adapter.py
@@ -306,8 +306,9 @@ class BLEAdapter(BLEDriverObserver):
                 # See:
                 #  https://github.com/NordicSemiconductor/pc-ble-driver-py/issues/38
                 for s in response["services"]:
-                    s.uuid.base = base
-                self.db_conns[conn_handle].services.extend(response["services"])
+                    if s.uuid.value != BLEUUID.Standard.unknown:
+                        s.uuid.base = base
+                        self.db_conns[conn_handle].services.append(s)
 
         for s in self.db_conns[conn_handle].services:
             self.driver.ble_gattc_char_disc(conn_handle, s.start_handle, s.end_handle)


### PR DESCRIPTION
Fixes issue where both the originally discovered vs service and the one manually added through ble_vs_uuid_add() are added to the database. Only the manually added service is added after this change.