### PR TITLE
Updated support for GAP AD and address types

### DIFF
--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -797,6 +797,18 @@ class BLEAdvData(object):
         information_3d_data = driver.BLE_GAP_AD_TYPE_3D_INFORMATION_DATA
         manufacturer_specific_data = driver.BLE_GAP_AD_TYPE_MANUFACTURER_SPECIFIC_DATA
 
+        # Additional official AD types from
+        # https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile/
+        indoor_positioning = 0x25
+        transport_discovery_data = 0x26
+        le_supported_features = 0x27
+        channel_map_update_indication = 0x28
+        pb_adv = 0x29
+        mesh_message = 0x2A
+        mesh_beacon = 0x2B
+        biginfo = 0x2C
+        broadcast_code = 0x2D
+
     def __init__(self, **kwargs):
         self.records = dict()
         for k in kwargs:
@@ -853,11 +865,11 @@ class BLEAdvData(object):
                 ad_type = ad_list[index + 1]
                 offset = index + 2
                 key = BLEAdvData.Types(ad_type)
-                ble_adv_data.records[key] = ad_list[offset : offset + ad_len - 1]
+                ble_adv_data.records[key] = ad_list[offset: offset + ad_len - 1]
             except ValueError:
                 if ad_type:
                     logger.info(
-                        "Invalid advertising data type: 0x{:02X}".format(ad_type)
+                        "Unknown advertising data type: 0x{:02X}".format(ad_type)
                     )
                 else:
                     logger.info("Invalid advertising data")


### PR DESCRIPTION
Make ble-driver-py less brittle and more up to date with regards to parsing of incoming advertising reports.

NCP-2721