### PR TITLE
Revert "Duplicate vs discovered services when calling adapter.service_discovery()"

### DIFF
--- a/pc_ble_driver_py/ble_adapter.py
+++ b/pc_ble_driver_py/ble_adapter.py
@@ -324,9 +324,8 @@ class BLEAdapter(BLEDriverObserver):
                 # See:
                 #  https://github.com/NordicSemiconductor/pc-ble-driver-py/issues/38
                 for s in response["services"]:
-                    if s.uuid.value != BLEUUID.Standard.unknown:
-                        s.uuid.base = base
-                        self.db_conns[conn_handle].services.append(s)
+                    s.uuid.base = base
+                self.db_conns[conn_handle].services.extend(response["services"])
 
         for s in self.db_conns[conn_handle].services:
             self.driver.ble_gattc_char_disc(conn_handle, s.start_handle, s.end_handle)


### PR DESCRIPTION
Reverts NordicSemiconductor/pc-ble-driver-py#167
The change has been found to introduce regression failures in certain cases (NCP-3349)