### PR TITLE
BLEGattsAttrMD: read_perm and write_perm

### DIFF
--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -403,6 +403,7 @@ class BLEGapConnSecMode(object):
         """BLE_GAP_CONN_SEC_MODE_SET_SIGNED_NO_MITM"""
         self.sm = 2
         self.lv = 1
+
     def set_signed_with_mitm(self):
         """BLE_GAP_CONN_SEC_MODE_SET_SIGNED_WITH_MITM"""
         self.sm = 2
@@ -423,7 +424,7 @@ class BLEGapConnSecMode(object):
         return sec_mode
 
     def __str__(self):
-        return "sm({0.ssm}) lv({0.lv}))".format(
+        return "sm({0.sm}) lv({0.lv}))".format(
             self
         )    
 

--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -366,6 +366,22 @@ class BLEGapScanParams(object):
 
         return scan_params
 
+class BLEGapConnSecMode(object):
+    def __init__(self, sm, lv):
+        self.sm = sm
+        self.lv = lv
+
+    @classmethod
+    def from_c(cls, conn_sec_mode):
+        return cls(
+            sm=conn_sec_mode.sm,
+            lv=conn_sec_mode.lv,
+        )
+
+    def __str__(self):
+        return "sm({0.ssm}) lv({0.lv}))".format(
+            self
+        )    
 
 class BLEGapConnSec(object):
     def __init__(self, sec_mode, level, encr_key_size):
@@ -1175,6 +1191,10 @@ class BLEGattsAttrMD(object):
     def to_c(self):
         attr_md = driver.ble_gatts_attr_md_t()
         attr_md.vloc = self.vloc
+        logger.warning("Testing read_perm")
+        attr_md.read_perm = driver.ble_gap_conn_sec_mode_t()
+        attr_md.read_perm.sm=1
+        attr_md.read_perm.lv=1
         attr_md.rd_auth = int(self.rd_auth)
         attr_md.wr_auth = int(self.wr_auth)
         attr_md.vlen = self.vlen

--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -367,16 +367,57 @@ class BLEGapScanParams(object):
         return scan_params
 
 class BLEGapConnSecMode(object):
-    def __init__(self, sm, lv):
+    def __init__(self, sm=0, lv=0):
         self.sm = sm
         self.lv = lv
+        
+    def set_no_access(self):
+        """BLE_GAP_CONN_SEC_MODE_SET_NO_ACCESS"""
+        self.sm = 0
+        self.lv = 0
+        
+    def set_open(self):
+        """BLE_GAP_CONN_SEC_MODE_SET_OPEN"""
+        self.sm = 1
+        self.lv = 1
+        
+    def set_enc_no_mitm(self):
+        """BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM"""
+        self.sm = 1
+        self.lv = 2
+        
+    def set_enc_with_mitm(self):
+        """BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM"""
+        self.sm = 1
+        self.lv = 3
+        
+    def set_lesc_enc_with_mitm(self): 
+        """BLE_GAP_CONN_SEC_MODE_SET_LESC_ENC_WITH_MITM"""
+        self.sm = 1
+        self.lv = 4
+    
+    def set_signed_no_mitm(self):
+        """BLE_GAP_CONN_SEC_MODE_SET_SIGNED_NO_MITM"""
+        self.sm = 2
+        self.lv = 1
+    def set_signed_with_mitm(self):
+        """BLE_GAP_CONN_SEC_MODE_SET_SIGNED_WITH_MITM"""
+        self.sm = 2
+        self.lv = 2
 
     @classmethod
-    def from_c(cls, conn_sec_mode):
+    def from_c(cls, sec_mode):
         return cls(
-            sm=conn_sec_mode.sm,
-            lv=conn_sec_mode.lv,
+            sm=sec_mode.sm,
+            lv=sec_mode.lv,
         )
+        
+    def to_c(self):
+        sec_mode = driver.ble_gap_conn_sec_mode_t()
+        sec_mode.sm = self.sm
+        sec_mode.lv = self.lv
+        
+        return sec_mode
 
     def __str__(self):
         return "sm({0.ssm}) lv({0.lv}))".format(
@@ -1182,19 +1223,22 @@ class BLEGattCharProps(object):
 
 class BLEGattsAttrMD(object):
     def __init__(self, vloc=driver.BLE_GATTS_VLOC_STACK,
-                 rd_auth=False, wr_auth=False, vlen=1):
+                 rd_auth=False, wr_auth=False, 
+                 read_perm=None, write_perm=None, vlen=1):
         self.vloc = vloc
         self.rd_auth = rd_auth
         self.wr_auth = wr_auth
+        self.read_perm = read_perm
+        self.write_perm = write_perm
         self.vlen = vlen
 
     def to_c(self):
         attr_md = driver.ble_gatts_attr_md_t()
         attr_md.vloc = self.vloc
-        logger.warning("Testing read_perm")
-        attr_md.read_perm = driver.ble_gap_conn_sec_mode_t()
-        attr_md.read_perm.sm=1
-        attr_md.read_perm.lv=1
+        if self.read_perm:
+            attr_md.read_perm = self.read_perm.to_c()
+        if self.write_perm:
+            attr_md.write_perm = self.write_perm.to_c()
         attr_md.rd_auth = int(self.rd_auth)
         attr_md.wr_auth = int(self.wr_auth)
         attr_md.vlen = self.vlen

--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -429,21 +429,20 @@ class BLEGapConnSecMode(object):
         )    
 
 class BLEGapConnSec(object):
-    def __init__(self, sec_mode, level, encr_key_size):
+    def __init__(self, sec_mode, encr_key_size):
+        assert isinstance(sec_mode, BLEGapConnSecMode), "Invalid argument type"
         self.sec_mode = sec_mode
-        self.level = level
         self.encr_key_size = encr_key_size
 
     @classmethod
     def from_c(cls, conn_sec):
         return cls(
-            sec_mode=conn_sec.sec_mode.sm,
-            level=conn_sec.sec_mode.lv,
+            sec_mode=BLEGapConnSecMode.from_c(conn_sec.sec_mode),
             encr_key_size=conn_sec.encr_key_size,
         )
 
     def __str__(self):
-        return "sec_mode({0.sec_mode}) level({0.level}) encr_key_size({0.encr_key_size})".format(
+        return "sec_mode({0.sec_mode}) encr_key_size({0.encr_key_size})".format(
             self
         )
 

--- a/pc_ble_driver_py/observers.py
+++ b/pc_ble_driver_py/observers.py
@@ -352,7 +352,7 @@ class BLEAdapterObserver(object):
     def __init__(self, *args, **kwargs):
         super(BLEAdapterObserver, self).__init__()
 
-    def on_indication(self, ble_adpater, conn_handle, uuid, data):
+    def on_indication(self, ble_adapter, conn_handle, uuid, data):
         pass
 
     def on_indication_handle(self, ble_adapter, conn_handle, uuid, attr_handle, data):

--- a/tests/test_lesc_security.py
+++ b/tests/test_lesc_security.py
@@ -192,6 +192,9 @@ class Peripheral(BLEDriverObserver, BLEAdapterObserver):
         logger.info("Peripheral on_gap_evt_passkey_display.")
         passkeyQueue.put(passkey)
 
+    def on_gap_evt_conn_sec_update(self, ble_driver, conn_handle, conn_sec):
+        logger.info(f"Conn sec update: {conn_sec}")
+
     def on_gap_evt_auth_status(
                         self,
                         ble_driver,


### PR DESCRIPTION
When trying to read a characteristic I was getting READ_NOT_PERMITTED. I would like to discuss how to add the functionality of BLE_GAP_CONN_SEC_MODE_SET_OPEN() and friends to pc_ble_driver_py, to control the read_perm and write_perm of BLEGattsAttrMD.

I have made some tests with adding this line to BLEGattsAttrMD:

    attr_md.read_perm = driver.ble_gap_conn_sec_mode_t()

After that, it is possible to assign the sm and lv properties:

     attr_md.read_perm.sm=1
     attr_md.read_perm.lv=1

I also started implementing a class BLEGapConnSecMode for the ble_gap_conn_sec_mode_t but now I need help. How do I proceed?

Edit: Ok, I think I start to understand the structure of this. What do you think about my suggested set_no_access() and set_open() methods in BLEGapConnSecMode? Is this the way to go? This allows for this kind of code:

        read_perm = BLEGapConnSecMode()
        read_perm.set_open()
        write_perm = BLEGapConnSecMode()
        write_perm.set_open()
        
        attr_md = BLEGattsAttrMD(read_perm=read_perm, write_perm=write_perm)
        attr = BLEGattsAttr(uuid=char_128_uuid, attr_md=attr_md,
                            max_len=max_len, value=value)
        self.adapter.driver.ble_gatts_characteristic_add(
                            serv_128_handle.handle,
                            char_md, attr, char_128_handles)