### PR TITLE
Feature/ble gap device name set

### DIFF
--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -366,6 +366,22 @@ class BLEGapScanParams(object):
 
         return scan_params
 
+class BLEGapConnSecMode(object):
+    def __init__(self, sm, lv):
+        self.sm = sm
+        self.lv = lv
+
+    @classmethod
+    def from_c(cls, conn_sec_mode):
+        return cls(
+            sm=conn_sec_mode.sm,
+            lv=conn_sec_mode.lv,
+        )
+
+    def __str__(self):
+        return "sm({0.ssm}) lv({0.lv}))".format(
+            self
+        )    
 
 class BLEGapConnSec(object):
     def __init__(self, sec_mode, level, encr_key_size):
@@ -1175,6 +1191,10 @@ class BLEGattsAttrMD(object):
     def to_c(self):
         attr_md = driver.ble_gatts_attr_md_t()
         attr_md.vloc = self.vloc
+        logger.warning("Testing read_perm")
+        attr_md.read_perm = driver.ble_gap_conn_sec_mode_t()
+        attr_md.read_perm.sm=1
+        attr_md.read_perm.lv=1
         attr_md.rd_auth = int(self.rd_auth)
         attr_md.wr_auth = int(self.wr_auth)
         attr_md.vlen = self.vlen

--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -2066,6 +2066,26 @@ class BLEDriver(object):
         return driver.sd_ble_gap_adv_data_set(
             self.rpc_adapter, p_adv_data, adv_data_len, p_scan_data, scan_data_len
         )
+        
+    @NordicSemiErrorCheck
+    @wrapt.synchronized(api_lock)
+    def ble_gap_device_name_set(self, name, device_name_read_only=True):
+        write_perm=BLEGapConnSecMode()
+        if device_name_read_only:
+            write_perm.sm = 0
+            write_perm.lv = 0
+        else:
+            write_perm.sm = 1
+            write_perm.lv = 1
+        p_write_perm = write_perm.to_c()
+        p_dev_name = name
+        p_dev_name = util.list_to_uint8_array([ord(x) for x in name])
+        p_dev_name_cast = p_dev_name.cast()
+        name_length = len(name)
+
+        return driver.sd_ble_gap_device_name_set(
+            self.rpc_adapter, p_write_perm, p_dev_name_cast, name_length
+        )
 
     @NordicSemiErrorCheck
     @wrapt.synchronized(api_lock)

--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -1328,8 +1328,11 @@ class BLEGattsCharMD(object):
         char_md = driver.ble_gatts_char_md_t()
         char_md.char_props = self.char_props.to_c()
         if self.user_desc:
-            char_md.p_char_user_desc = util.list_to_char_array(self.user_desc)
+            user_desc_array=util.list_to_uint8_array(self.user_desc)
+            user_desc_array_cast = user_desc_array.cast()
+            char_md.p_char_user_desc = user_desc_array_cast
             char_md.char_user_desc_size = len(self.user_desc)
+            char_md.char_user_desc_max_size = len(self.user_desc)
         if self.pf:
             char_md.p_char_pf = self.pf.to_c()
         if self.desc_md:

--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -367,16 +367,57 @@ class BLEGapScanParams(object):
         return scan_params
 
 class BLEGapConnSecMode(object):
-    def __init__(self, sm, lv):
+    def __init__(self, sm=0, lv=0):
         self.sm = sm
         self.lv = lv
+        
+    def set_no_access(self):
+        """BLE_GAP_CONN_SEC_MODE_SET_NO_ACCESS"""
+        self.sm = 0
+        self.lv = 0
+        
+    def set_open(self):
+        """BLE_GAP_CONN_SEC_MODE_SET_OPEN"""
+        self.sm = 1
+        self.lv = 1
+        
+    def set_enc_no_mitm(self):
+        """BLE_GAP_CONN_SEC_MODE_SET_ENC_NO_MITM"""
+        self.sm = 1
+        self.lv = 2
+        
+    def set_enc_with_mitm(self):
+        """BLE_GAP_CONN_SEC_MODE_SET_ENC_WITH_MITM"""
+        self.sm = 1
+        self.lv = 3
+        
+    def set_lesc_enc_with_mitm(self): 
+        """BLE_GAP_CONN_SEC_MODE_SET_LESC_ENC_WITH_MITM"""
+        self.sm = 1
+        self.lv = 4
+    
+    def set_signed_no_mitm(self):
+        """BLE_GAP_CONN_SEC_MODE_SET_SIGNED_NO_MITM"""
+        self.sm = 2
+        self.lv = 1
+    def set_signed_with_mitm(self):
+        """BLE_GAP_CONN_SEC_MODE_SET_SIGNED_WITH_MITM"""
+        self.sm = 2
+        self.lv = 2
 
     @classmethod
-    def from_c(cls, conn_sec_mode):
+    def from_c(cls, sec_mode):
         return cls(
-            sm=conn_sec_mode.sm,
-            lv=conn_sec_mode.lv,
+            sm=sec_mode.sm,
+            lv=sec_mode.lv,
         )
+        
+    def to_c(self):
+        sec_mode = driver.ble_gap_conn_sec_mode_t()
+        sec_mode.sm = self.sm
+        sec_mode.lv = self.lv
+        
+        return sec_mode
 
     def __str__(self):
         return "sm({0.ssm}) lv({0.lv}))".format(
@@ -1182,19 +1223,22 @@ class BLEGattCharProps(object):
 
 class BLEGattsAttrMD(object):
     def __init__(self, vloc=driver.BLE_GATTS_VLOC_STACK,
-                 rd_auth=False, wr_auth=False, vlen=1):
+                 rd_auth=False, wr_auth=False, 
+                 read_perm=None, write_perm=None, vlen=1):
         self.vloc = vloc
         self.rd_auth = rd_auth
         self.wr_auth = wr_auth
+        self.read_perm = read_perm
+        self.write_perm = write_perm
         self.vlen = vlen
 
     def to_c(self):
         attr_md = driver.ble_gatts_attr_md_t()
         attr_md.vloc = self.vloc
-        logger.warning("Testing read_perm")
-        attr_md.read_perm = driver.ble_gap_conn_sec_mode_t()
-        attr_md.read_perm.sm=1
-        attr_md.read_perm.lv=1
+        if self.read_perm:
+            attr_md.read_perm = self.read_perm.to_c()
+        if self.write_perm:
+            attr_md.write_perm = self.write_perm.to_c()
         attr_md.rd_auth = int(self.rd_auth)
         attr_md.wr_auth = int(self.wr_auth)
         attr_md.vlen = self.vlen


### PR DESCRIPTION
This is a branch aiming to fix the issue discussed in this thread:
https://devzone.nordicsemi.com/f/nordic-q-a/71774/device-name-shows-garbage-using-pc_ble_driver_py

Example code:
Setting a read-only device name:

    ble_driver.ble_gap_device_name_set(name="Joh")

Setting a writable device name:

    ble_driver.ble_gap_device_name_set(name="Joh2", device_name_read_only=False)
