### PR TITLE
Fix/migrate to 39

### DIFF
--- a/pc_ble_driver_py/__init__.py
+++ b/pc_ble_driver_py/__init__.py
@@ -39,5 +39,4 @@ Package marker file.
 
 """
 
-
 __version__ = "0.15.1"

--- a/pc_ble_driver_py/__init__.py
+++ b/pc_ble_driver_py/__init__.py
@@ -40,4 +40,4 @@ Package marker file.
 """
 
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
     ],
     keywords='nordic nrf51 nrf52 ble bluetooth softdevice serialization bindings pc-ble-driver pc-ble-driver-py '
              'pc_ble_driver pc_ble_driver_py',
-    python_requires=">=3.6, <3.9",
+    python_requires=">=3.6, <3.10",
     install_requires=requirements,
     packages=packages,
     package_data={

--- a/swig/pc_ble_driver.i.in
+++ b/swig/pc_ble_driver.i.in
@@ -197,30 +197,30 @@ std::shared_ptr<adapter_context_t> adapter_context_find(adapter_t *adapter_ptr)
 
 %{
 
-// #include <iostream>    
+
 #include <mutex>
 #include <string>
 
 
-class GILStateWrapper{
-    // Ensure the python GIL is a state such that SWIG functions can be called within a scope
-    private:
-        PyGILState_STATE gstate;
-        std::string lock_action_debug_message;
-        std::lock_guard<std::recursive_mutex> lock; 
-        static std::recursive_mutex GIL_MUTEX; 
-    public: 
-        GILStateWrapper(char* _unused_debug_message) : lock_action_debug_message(_unused_debug_message), lock(GILStateWrapper::GIL_MUTEX) {
-            this->gstate = PyGILState_Ensure();
-        }
-        GILStateWrapper(): GILStateWrapper("") {
-        }    
-        ~GILStateWrapper(){
-            PyGILState_Release(this->gstate);
-        }
-};
+    class GILStateWrapper{
+        // Ensure the python GIL is a state such that SWIG functions can be called within a scope
+        private:
+            PyGILState_STATE gstate;
+            std::string lock_action_debug_message;
+            std::lock_guard<std::recursive_mutex> lock; 
+            static std::recursive_mutex GIL_MUTEX; 
+        public: 
+            GILStateWrapper(const char* _unused_debug_message) : lock_action_debug_message(_unused_debug_message), lock(GILStateWrapper::GIL_MUTEX) {
+                this->gstate = PyGILState_Ensure();
+            }
+            GILStateWrapper(): GILStateWrapper("") {
+            }    
+            ~GILStateWrapper(){
+                PyGILState_Release(this->gstate);
+            }
+    };
 
-std::recursive_mutex GILStateWrapper::GIL_MUTEX;
+    std::recursive_mutex GILStateWrapper::GIL_MUTEX;
 
 %}
 
@@ -335,7 +335,6 @@ static void PythonStatusCallBack(adapter_t *adapter, sd_rpc_app_status_t status_
     // For information regarding GIL and copying of data, please look at
     // function PythonEvtCallBack.
 
-    // gstate = PyGILState_Ensure();
     GILStateWrapper GIL_lock("PythonStatusCallBack"); 
 
     adapter_obj = SWIG_NewPointerObj(SWIG_as_voidptr(adapter), SWIGTYPE_p_adapter_t, 0 |  0 );

--- a/swig/pc_ble_driver.i.in
+++ b/swig/pc_ble_driver.i.in
@@ -195,76 +195,33 @@ std::shared_ptr<adapter_context_t> adapter_context_find(adapter_t *adapter_ptr)
 %}
 
 
-%{// TODO Delete me
-    //TODO: Remove this hotfix-block 
+%{
 
-
-
-
-
-
-#include <iostream>    
+// #include <iostream>    
 #include <mutex>
 #include <string>
-#include <atomic> 
 
 
-class GILStateWrapper{// Ensure gil state, and release it when leaving scope
+class GILStateWrapper{
+    // Ensure the python GIL is a state such that SWIG functions can be called within a scope
     private:
         PyGILState_STATE gstate;
-        std::string name;
+        std::string lock_action_debug_message;
         std::lock_guard<std::recursive_mutex> lock; 
+        static std::recursive_mutex GIL_MUTEX; 
     public: 
-        static std::recursive_mutex OUTER_MUTEX; 
-
-        GILStateWrapper(char* name) : name(name), lock(GILStateWrapper::OUTER_MUTEX) {
-            std::thread::id this_id = std::this_thread::get_id();
-            // std::cout << "{\"Locking " << std::string(name) << "(" << this_id << ")" << "\" :";
+        GILStateWrapper(char* _unused_debug_message) : lock_action_debug_message(_unused_debug_message), lock(GILStateWrapper::GIL_MUTEX) {
             this->gstate = PyGILState_Ensure();
-            // std::cout << " [ " << std:: endl; 
-
         }
         GILStateWrapper(): GILStateWrapper("") {
         }    
         ~GILStateWrapper(){
-            std::thread::id this_id = std::this_thread::get_id();
-            // std::cout << "\"Freeing " << this->name << "(" << this_id << ")" << "\"]}," << std:: endl; 
             PyGILState_Release(this->gstate);
         }
 };
 
-std::recursive_mutex GILStateWrapper::OUTER_MUTEX; 
-// std::recursive_mutex callback_mutex; // A segfault happens in python 3.9, that is solved by adding this  
-// std::mutex callback_mutex; // A segfault happens in python 3.9, that is solved by adding this  
+std::recursive_mutex GILStateWrapper::GIL_MUTEX;
 
-// class InitialisationAnouncer{
-//     public:
-//     InitialisationAnouncer(const char* name){
-//         std::thread::id this_id = std::this_thread::get_id();
-//         std::cout << "{\"Locking " << std::string(name) << "(" << this_id << ")" << "\" :[ " << std:: endl; 
-
-//     }
-// };
-// class PrintingLockWrapper{
-//     public: 
-//     InitialisationAnouncer filler; 
-//     // std::lock_guard<std::recursive_mutex> lock;
-//     std::lock_guard<std::mutex> lock;
-//     std::string name;
-//     // PrintingLockWrapper(const char* name, std::recursive_mutex &mutex): 
-//     PrintingLockWrapper(const char* name, std::mutex &mutex): 
-//             filler(name) 
-//             , lock(mutex) 
-//             {
-//         this->name = std::string(name); 
-
-//     } 
-//     ~PrintingLockWrapper(){
-//         std::thread::id this_id = std::this_thread::get_id();
-//         std::cout << "\"Freeing " << this->name << "(" << this_id << ")" << "\"]}," << std:: endl; 
-//     }
-
-// }; 
 %}
 
 /* Event callback handling */
@@ -275,19 +232,9 @@ static void PythonEvtCallBack(adapter_t *adapter, ble_evt_t *ble_event)
     PyObject *arglist;
     PyObject *adapter_obj;
     PyObject *ble_evt_obj;
-    //PyGILState_STATE gstate; //TODO Uncomment if the GIL lock was bad
     ble_evt_t* copied_ble_event;
     PyObject *result;
 
-    // if (! callback_mutex.try_lock()){
-    //     std::cout << "Skipping PythonEvtCallBack" << "(" << std::this_thread::get_id() << ")"<< std::endl;
-    //     return; 
-    // }
-    // else{
-
-    //     std::cout << "Running PythonEvtCallBack" << "(" << std::this_thread::get_id() << ")"<< std::endl;
-    // }
-    // PrintingLockWrapper lock("PythonEvtCallBack", callback_mutex); 
     //TODO Fix the deprecation waringngs on 3.9
     auto adapter_context = adapter_context_find(adapter);
 
@@ -331,9 +278,7 @@ static void PythonEvtCallBack(adapter_t *adapter, ble_evt_t *ble_event)
     memcpy(copied_ble_event, ble_event, ble_event->header.evt_len + length_correction);
 #endif
 
-    // Handling of Python Global Interpretor Lock (GIL)
-    //TODO Verify that the wrapper is good
-    // gstate = PyGILState_Ensure(); //TODO Uncomment if the wrapper was bad 
+
     GILStateWrapper GIL_lock("PythonEvtCallback"); 
 
 
@@ -350,9 +295,7 @@ static void PythonEvtCallBack(adapter_t *adapter, ble_evt_t *ble_event)
     Py_XDECREF(ble_evt_obj);
     Py_DECREF(arglist);
 
-    // PyGILState_Release(gstate); //TODO Uncomment if the wrapper was bad 
 
-    // callback_mutex.unlock(); // TODO Delete this unlock
 }
 %}
 
@@ -366,22 +309,8 @@ static void PythonStatusCallBack(adapter_t *adapter, sd_rpc_app_status_t status_
     PyObject *adapter_obj;
     PyObject *status_code_obj;
     PyObject *status_message_obj;
-    //PyGILState_STATE gstate; //TODO Uncomment if the GIL lock was bad
     PyObject *result;
 
-    // int lock_status = std::try_lock(callback_mutex); 
-    // if (lock_status != 0){
-    // if (! callback_mutex.try_lock()){
-    //     std::cout << "Skipping PythonStatusCallback" << "(" << std::this_thread::get_id() << ")"<< std::endl;
-    //     return;
-    // }
-    // else{
-
-    //     std::cout << "Running PythonEvtCallBack" << "(" << std::this_thread::get_id() << ")"<< std::endl;
-    // }
-    //std::cout << "Locking PythonStatusCallBack" << std::endl;
-    // PrintingLockWrapper unlock_messager("PythonStatusCallBack", callback_mutex);
-    //std::lock_guard<std::recursive_mutex> lock(callback_mutex); // TODO See if the segfault is handled
     auto adapter_context = adapter_context_find(adapter);
 
     if (!adapter_context)
@@ -424,8 +353,7 @@ static void PythonStatusCallBack(adapter_t *adapter, sd_rpc_app_status_t status_
     Py_XDECREF(status_message_obj);
     Py_DECREF(arglist);
 
-    // PyGILState_Release(gstate); //TODO Uncomment if the wrapper was bad 
-    // callback_mutex.unlock();
+
 }
 %}
 
@@ -438,21 +366,8 @@ static void PythonLogCallBack(adapter_t *adapter, sd_rpc_log_severity_t severity
     PyObject *adapter_obj;
     PyObject *severity_obj;
     PyObject *message_obj;
-    //PyGILState_STATE gstate; //TODO Uncomment if the GIL lock was bad
     PyObject *result;
 
-    // int lock_status = std::try_lock(callback_mutex); 
-    // if (! callback_mutex.try_lock()){
-    //     std::cout << "Skipping PythonLogCallBack" << "(" << std::this_thread::get_id() << ")"<< std::endl;
-    //     return; 
-    // }
-    // else{
-
-    //     std::cout << "Running PythonEvtCallBack" << "(" << std::this_thread::get_id() << ")"<< std::endl;
-    // }
-    // std::cout << "Locking PythonLogCallBack" << std::endl;
-    // PrintingLockWrapper unlock_messager("PythonLogCallBack", callback_mutex);
-    //std::lock_guard<std::recursive_mutex> lock(callback_mutex); // TODO See if the segfault is handled
     auto adapter_context = adapter_context_find(adapter);
 
     if (!adapter_context)
@@ -477,7 +392,6 @@ static void PythonLogCallBack(adapter_t *adapter, sd_rpc_log_severity_t severity
     // For information regarding GIL and copying of data, please look at
     // function PythonEvtCallBack.
 
-    // gstate = PyGILState_Ensure();//TODO UNCOMMENT if the GIL wrapper was bad
     GILStateWrapper GIL_lock("PythonLogCallBack"); 
 
     adapter_obj = SWIG_NewPointerObj(SWIG_as_voidptr(adapter), SWIGTYPE_p_adapter_t, 0 |  0 );
@@ -495,8 +409,7 @@ static void PythonLogCallBack(adapter_t *adapter, sd_rpc_log_severity_t severity
     Py_XDECREF(severity_obj);
     Py_DECREF(arglist);
 
-    // PyGILState_Release(gstate);//TODO Uncomment if the wrapper was bad 
-    // callback_mutex.unlock();
+;
 }
 %}
 
@@ -512,13 +425,9 @@ PyObject* sd_rpc_open_py(PyObject *adapter, PyObject *py_status_handler, PyObjec
     uint32_t result;
     std::shared_ptr<adapter_context_t> ctx{nullptr};
 
-    // PrintingLockWrapper unlock_messager("sd_rpc_open_py", callback_mutex); // TODO See if the segfault is handled
 
-    // auto gstate = PyGILState_Ensure();//TODO UNCOMMENT if the GIL wrapper was bad
     {
-        // std::cout << "sd_rpc_open_py First lock begin" << std::endl;
         GILStateWrapper GIL_lock("sd_rpc_open_py"); 
-        // std::cout << "sd_rpc_open_py First lock end" << std::endl;
 
 
         res1 = SWIG_ConvertPtr(adapter, &argp1,SWIGTYPE_p_adapter_t, 0 |  0 );
@@ -549,7 +458,6 @@ PyObject* sd_rpc_open_py(PyObject *adapter, PyObject *py_status_handler, PyObjec
        GILStateWrapper GIL_lock("sd_rpc_open_py_2"); 
        resultobj = SWIG_From_unsigned_SS_int((unsigned int) (result));
     }
-    // PyGILState_Release(gstate);//TODO Uncomment if the wrapper was bad 
     return resultobj;
 
 fail:
@@ -563,21 +471,12 @@ PyObject *sd_rpc_close_py(PyObject *adapter) {
     int res1 = 0;
     uint32_t result;
     std::shared_ptr<adapter_context_t> ctx{nullptr};
-    //PyGILState_STATE gstate; //TODO Uncomment if the GIL lock was bad
 
-
-
-    //std::cout << "Locking sd_rpc_close" << std::endl;
-    // PrintingLockWrapper unlock_messager("sd_rpc_close_py", callback_mutex);
-    // std::lock_guard<std::recursive_mutex> lock(callback_mutex); // TODO See if the segfault is handled
-    // gstate = PyGILState_Ensure();//todo UNCOMMENT if the GIL wrapper was bad
 
 
 
     {
-        // std::cout << "Begin lock" << std::endl;
         GILStateWrapper GIL_lock("sd_rpc_close_py_1"); 
-        // std::cout << "End lock" << std::endl;
         res1 = SWIG_ConvertPtr(adapter, &argp1, SWIGTYPE_p_adapter_t, 0 |  0 );
         if (!SWIG_IsOK(res1)) {
             SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "sd_rpc_close" "', argument " "1"" of type '" "adapter_t *""'");
@@ -610,7 +509,6 @@ PyObject *sd_rpc_close_py(PyObject *adapter) {
 
 
             resultobj = SWIG_From_unsigned_SS_int((unsigned int)(result));
-            // PyGILState_Release(gstate);//TODO Uncomment if the wrapper was bad 
         }
         return resultobj;
     }

--- a/swig/pc_ble_driver.i.in
+++ b/swig/pc_ble_driver.i.in
@@ -195,6 +195,78 @@ std::shared_ptr<adapter_context_t> adapter_context_find(adapter_t *adapter_ptr)
 %}
 
 
+%{// TODO Delete me
+    //TODO: Remove this hotfix-block 
+
+
+
+
+
+
+#include <iostream>    
+#include <mutex>
+#include <string>
+#include <atomic> 
+
+
+class GILStateWrapper{// Ensure gil state, and release it when leaving scope
+    private:
+        PyGILState_STATE gstate;
+        std::string name;
+        std::lock_guard<std::recursive_mutex> lock; 
+    public: 
+        static std::recursive_mutex OUTER_MUTEX; 
+
+        GILStateWrapper(char* name) : name(name), lock(GILStateWrapper::OUTER_MUTEX) {
+            std::thread::id this_id = std::this_thread::get_id();
+            // std::cout << "{\"Locking " << std::string(name) << "(" << this_id << ")" << "\" :";
+            this->gstate = PyGILState_Ensure();
+            // std::cout << " [ " << std:: endl; 
+
+        }
+        GILStateWrapper(): GILStateWrapper("") {
+        }    
+        ~GILStateWrapper(){
+            std::thread::id this_id = std::this_thread::get_id();
+            // std::cout << "\"Freeing " << this->name << "(" << this_id << ")" << "\"]}," << std:: endl; 
+            PyGILState_Release(this->gstate);
+        }
+};
+
+std::recursive_mutex GILStateWrapper::OUTER_MUTEX; 
+// std::recursive_mutex callback_mutex; // A segfault happens in python 3.9, that is solved by adding this  
+// std::mutex callback_mutex; // A segfault happens in python 3.9, that is solved by adding this  
+
+// class InitialisationAnouncer{
+//     public:
+//     InitialisationAnouncer(const char* name){
+//         std::thread::id this_id = std::this_thread::get_id();
+//         std::cout << "{\"Locking " << std::string(name) << "(" << this_id << ")" << "\" :[ " << std:: endl; 
+
+//     }
+// };
+// class PrintingLockWrapper{
+//     public: 
+//     InitialisationAnouncer filler; 
+//     // std::lock_guard<std::recursive_mutex> lock;
+//     std::lock_guard<std::mutex> lock;
+//     std::string name;
+//     // PrintingLockWrapper(const char* name, std::recursive_mutex &mutex): 
+//     PrintingLockWrapper(const char* name, std::mutex &mutex): 
+//             filler(name) 
+//             , lock(mutex) 
+//             {
+//         this->name = std::string(name); 
+
+//     } 
+//     ~PrintingLockWrapper(){
+//         std::thread::id this_id = std::this_thread::get_id();
+//         std::cout << "\"Freeing " << this->name << "(" << this_id << ")" << "\"]}," << std:: endl; 
+//     }
+
+// }; 
+%}
+
 /* Event callback handling */
 %{
 static void PythonEvtCallBack(adapter_t *adapter, ble_evt_t *ble_event)
@@ -203,10 +275,20 @@ static void PythonEvtCallBack(adapter_t *adapter, ble_evt_t *ble_event)
     PyObject *arglist;
     PyObject *adapter_obj;
     PyObject *ble_evt_obj;
-    PyGILState_STATE gstate;
+    //PyGILState_STATE gstate; //TODO Uncomment if the GIL lock was bad
     ble_evt_t* copied_ble_event;
     PyObject *result;
 
+    // if (! callback_mutex.try_lock()){
+    //     std::cout << "Skipping PythonEvtCallBack" << "(" << std::this_thread::get_id() << ")"<< std::endl;
+    //     return; 
+    // }
+    // else{
+
+    //     std::cout << "Running PythonEvtCallBack" << "(" << std::this_thread::get_id() << ")"<< std::endl;
+    // }
+    // PrintingLockWrapper lock("PythonEvtCallBack", callback_mutex); 
+    //TODO Fix the deprecation waringngs on 3.9
     auto adapter_context = adapter_context_find(adapter);
 
     if (!adapter_context)
@@ -250,7 +332,10 @@ static void PythonEvtCallBack(adapter_t *adapter, ble_evt_t *ble_event)
 #endif
 
     // Handling of Python Global Interpretor Lock (GIL)
-    gstate = PyGILState_Ensure();
+    //TODO Verify that the wrapper is good
+    // gstate = PyGILState_Ensure(); //TODO Uncomment if the wrapper was bad 
+    GILStateWrapper GIL_lock("PythonEvtCallback"); 
+
 
     adapter_obj = SWIG_NewPointerObj(SWIG_as_voidptr(adapter), SWIGTYPE_p_adapter_t, 0 |  0 );
     // Create a Python object that points to the copied event, let the interpreter take care of
@@ -258,14 +343,16 @@ static void PythonEvtCallBack(adapter_t *adapter, ble_evt_t *ble_event)
     ble_evt_obj = SWIG_NewPointerObj(SWIG_as_voidptr(copied_ble_event), SWIGTYPE_p_ble_evt_t, SWIG_POINTER_OWN);
     arglist = Py_BuildValue("(OO)", adapter_obj, ble_evt_obj);
 
-    result = PyEval_CallObject(func, arglist);
+    result = PyObject_Call(func, arglist, NULL);
 
     Py_XDECREF(result);
     Py_XDECREF(adapter_obj);
     Py_XDECREF(ble_evt_obj);
     Py_DECREF(arglist);
 
-    PyGILState_Release(gstate);
+    // PyGILState_Release(gstate); //TODO Uncomment if the wrapper was bad 
+
+    // callback_mutex.unlock(); // TODO Delete this unlock
 }
 %}
 
@@ -279,9 +366,22 @@ static void PythonStatusCallBack(adapter_t *adapter, sd_rpc_app_status_t status_
     PyObject *adapter_obj;
     PyObject *status_code_obj;
     PyObject *status_message_obj;
-    PyGILState_STATE gstate;
+    //PyGILState_STATE gstate; //TODO Uncomment if the GIL lock was bad
     PyObject *result;
 
+    // int lock_status = std::try_lock(callback_mutex); 
+    // if (lock_status != 0){
+    // if (! callback_mutex.try_lock()){
+    //     std::cout << "Skipping PythonStatusCallback" << "(" << std::this_thread::get_id() << ")"<< std::endl;
+    //     return;
+    // }
+    // else{
+
+    //     std::cout << "Running PythonEvtCallBack" << "(" << std::this_thread::get_id() << ")"<< std::endl;
+    // }
+    //std::cout << "Locking PythonStatusCallBack" << std::endl;
+    // PrintingLockWrapper unlock_messager("PythonStatusCallBack", callback_mutex);
+    //std::lock_guard<std::recursive_mutex> lock(callback_mutex); // TODO See if the segfault is handled
     auto adapter_context = adapter_context_find(adapter);
 
     if (!adapter_context)
@@ -306,7 +406,8 @@ static void PythonStatusCallBack(adapter_t *adapter, sd_rpc_app_status_t status_
     // For information regarding GIL and copying of data, please look at
     // function PythonEvtCallBack.
 
-    gstate = PyGILState_Ensure();
+    // gstate = PyGILState_Ensure();
+    GILStateWrapper GIL_lock("PythonStatusCallBack"); 
 
     adapter_obj = SWIG_NewPointerObj(SWIG_as_voidptr(adapter), SWIGTYPE_p_adapter_t, 0 |  0 );
     status_code_obj = SWIG_From_int((int)(status_code));
@@ -315,7 +416,7 @@ static void PythonStatusCallBack(adapter_t *adapter, sd_rpc_app_status_t status_
     status_message_obj = SWIG_Python_str_FromChar((const char *)status_message);
     arglist = Py_BuildValue("(OOO)", adapter_obj, status_code_obj, status_message_obj);
 
-    result = PyEval_CallObject(func, arglist);
+    result = PyObject_Call(func, arglist, NULL);
 
     Py_XDECREF(result);
     Py_XDECREF(adapter_obj);
@@ -323,7 +424,8 @@ static void PythonStatusCallBack(adapter_t *adapter, sd_rpc_app_status_t status_
     Py_XDECREF(status_message_obj);
     Py_DECREF(arglist);
 
-    PyGILState_Release(gstate);
+    // PyGILState_Release(gstate); //TODO Uncomment if the wrapper was bad 
+    // callback_mutex.unlock();
 }
 %}
 
@@ -336,9 +438,21 @@ static void PythonLogCallBack(adapter_t *adapter, sd_rpc_log_severity_t severity
     PyObject *adapter_obj;
     PyObject *severity_obj;
     PyObject *message_obj;
-    PyGILState_STATE gstate;
+    //PyGILState_STATE gstate; //TODO Uncomment if the GIL lock was bad
     PyObject *result;
 
+    // int lock_status = std::try_lock(callback_mutex); 
+    // if (! callback_mutex.try_lock()){
+    //     std::cout << "Skipping PythonLogCallBack" << "(" << std::this_thread::get_id() << ")"<< std::endl;
+    //     return; 
+    // }
+    // else{
+
+    //     std::cout << "Running PythonEvtCallBack" << "(" << std::this_thread::get_id() << ")"<< std::endl;
+    // }
+    // std::cout << "Locking PythonLogCallBack" << std::endl;
+    // PrintingLockWrapper unlock_messager("PythonLogCallBack", callback_mutex);
+    //std::lock_guard<std::recursive_mutex> lock(callback_mutex); // TODO See if the segfault is handled
     auto adapter_context = adapter_context_find(adapter);
 
     if (!adapter_context)
@@ -363,7 +477,8 @@ static void PythonLogCallBack(adapter_t *adapter, sd_rpc_log_severity_t severity
     // For information regarding GIL and copying of data, please look at
     // function PythonEvtCallBack.
 
-    gstate = PyGILState_Ensure();
+    // gstate = PyGILState_Ensure();//TODO UNCOMMENT if the GIL wrapper was bad
+    GILStateWrapper GIL_lock("PythonLogCallBack"); 
 
     adapter_obj = SWIG_NewPointerObj(SWIG_as_voidptr(adapter), SWIGTYPE_p_adapter_t, 0 |  0 );
     severity_obj = SWIG_From_int((int)(severity));
@@ -372,7 +487,7 @@ static void PythonLogCallBack(adapter_t *adapter, sd_rpc_log_severity_t severity
     message_obj = SWIG_Python_str_FromChar((const char *)log_message);
     arglist = Py_BuildValue("(OOO)", adapter_obj, severity_obj, message_obj);
 
-    result = PyEval_CallObject(func, arglist);
+    result = PyObject_Call(func, arglist, NULL);
 
     Py_XDECREF(result);
     Py_XDECREF(adapter_obj);
@@ -380,7 +495,8 @@ static void PythonLogCallBack(adapter_t *adapter, sd_rpc_log_severity_t severity
     Py_XDECREF(severity_obj);
     Py_DECREF(arglist);
 
-    PyGILState_Release(gstate);
+    // PyGILState_Release(gstate);//TODO Uncomment if the wrapper was bad 
+    // callback_mutex.unlock();
 }
 %}
 
@@ -396,30 +512,44 @@ PyObject* sd_rpc_open_py(PyObject *adapter, PyObject *py_status_handler, PyObjec
     uint32_t result;
     std::shared_ptr<adapter_context_t> ctx{nullptr};
 
-    res1 = SWIG_ConvertPtr(adapter, &argp1,SWIGTYPE_p_adapter_t, 0 |  0 );
-    if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "sd_rpc_open" "', argument " "1"" of type '" "adapter_t *""'");
-    }
+    // PrintingLockWrapper unlock_messager("sd_rpc_open_py", callback_mutex); // TODO See if the segfault is handled
 
-    arg1 = (adapter_t * ) (argp1);
-
-    // Try to register adapter_context_t
-    ctx = adapter_context_add(arg1);
-    if (!ctx)
+    // auto gstate = PyGILState_Ensure();//TODO UNCOMMENT if the GIL wrapper was bad
     {
-        SWIG_exception_fail(SWIG_ValueError, "Not able to register adapter_context_t for adapter");
+        // std::cout << "sd_rpc_open_py First lock begin" << std::endl;
+        GILStateWrapper GIL_lock("sd_rpc_open_py"); 
+        // std::cout << "sd_rpc_open_py First lock end" << std::endl;
+
+
+        res1 = SWIG_ConvertPtr(adapter, &argp1,SWIGTYPE_p_adapter_t, 0 |  0 );
+        if (!SWIG_IsOK(res1)) {
+        SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "sd_rpc_open" "', argument " "1"" of type '" "adapter_t *""'");
+        }
+
+        arg1 = (adapter_t * ) (argp1);
+
+        // Try to register adapter_context_t
+        ctx = adapter_context_add(arg1);
+        if (!ctx)
+        {
+            SWIG_exception_fail(SWIG_ValueError, "Not able to register adapter_context_t for adapter");
+        }
+
     }
+        Py_XINCREF(py_log_handler);
+        Py_XINCREF(py_status_handler);
+        Py_XINCREF(py_evt_handler);
 
-    Py_XINCREF(py_log_handler);
-    Py_XINCREF(py_status_handler);
-    Py_XINCREF(py_evt_handler);
-
-    ctx->log_callback = py_log_handler;
-    ctx->status_callback = py_status_handler;
-    ctx->event_callback = py_evt_handler;
+        ctx->log_callback = py_log_handler;
+        ctx->status_callback = py_status_handler;
+        ctx->event_callback = py_evt_handler;
 
     result = sd_rpc_open(arg1, PythonStatusCallBack, PythonEvtCallBack, PythonLogCallBack);
-    resultobj = SWIG_From_unsigned_SS_int((unsigned int) (result));
+    {
+       GILStateWrapper GIL_lock("sd_rpc_open_py_2"); 
+       resultobj = SWIG_From_unsigned_SS_int((unsigned int) (result));
+    }
+    // PyGILState_Release(gstate);//TODO Uncomment if the wrapper was bad 
     return resultobj;
 
 fail:
@@ -433,17 +563,31 @@ PyObject *sd_rpc_close_py(PyObject *adapter) {
     int res1 = 0;
     uint32_t result;
     std::shared_ptr<adapter_context_t> ctx{nullptr};
-    PyGILState_STATE gstate;
+    //PyGILState_STATE gstate; //TODO Uncomment if the GIL lock was bad
 
-    res1 = SWIG_ConvertPtr(adapter, &argp1, SWIGTYPE_p_adapter_t, 0 |  0 );
-    if (!SWIG_IsOK(res1)) {
-        SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "sd_rpc_close" "', argument " "1"" of type '" "adapter_t *""'");
+
+
+    //std::cout << "Locking sd_rpc_close" << std::endl;
+    // PrintingLockWrapper unlock_messager("sd_rpc_close_py", callback_mutex);
+    // std::lock_guard<std::recursive_mutex> lock(callback_mutex); // TODO See if the segfault is handled
+    // gstate = PyGILState_Ensure();//todo UNCOMMENT if the GIL wrapper was bad
+
+
+
+    {
+        // std::cout << "Begin lock" << std::endl;
+        GILStateWrapper GIL_lock("sd_rpc_close_py_1"); 
+        // std::cout << "End lock" << std::endl;
+        res1 = SWIG_ConvertPtr(adapter, &argp1, SWIGTYPE_p_adapter_t, 0 |  0 );
+        if (!SWIG_IsOK(res1)) {
+            SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "sd_rpc_close" "', argument " "1"" of type '" "adapter_t *""'");
+        }
+
     }
+        arg1 = (adapter_t *)(argp1);
+        result = sd_rpc_close(arg1);
 
-    arg1 = (adapter_t *)(argp1);
-    result = sd_rpc_close(arg1);
-
-    ctx = adapter_context_find(arg1);
+        ctx = adapter_context_find(arg1);
 
     if(!ctx)
     {
@@ -452,19 +596,22 @@ PyObject *sd_rpc_close_py(PyObject *adapter) {
     else
     {
         // Make sure that callbacks are not running before decrementing the callback reference count
-        std::lock_guard<std::mutex> lck(ctx->callback_mutex);
+        {
+            std::lock_guard<std::mutex> lck(ctx->callback_mutex);
+            
+            GILStateWrapper GIL_lock("sd_rpc_close_py_2"); 
 
-        gstate = PyGILState_Ensure();
+            Py_XDECREF(ctx->event_callback);
+            Py_XDECREF(ctx->status_callback);
+            Py_XDECREF(ctx->log_callback);
 
-        Py_XDECREF(ctx->event_callback);
-        Py_XDECREF(ctx->status_callback);
-        Py_XDECREF(ctx->log_callback);
+            adapter_context_remove(arg1);
 
-        adapter_context_remove(arg1);
 
-        PyGILState_Release(gstate);
 
-        resultobj = SWIG_From_unsigned_SS_int((unsigned int)(result));
+            resultobj = SWIG_From_unsigned_SS_int((unsigned int)(result));
+            // PyGILState_Release(gstate);//TODO Uncomment if the wrapper was bad 
+        }
         return resultobj;
     }
 


### PR DESCRIPTION
3.9 has stricter requirements for the GIL state to be properly specified when using SWIG-functions. Even the semi-pure ones that only return a python-object pointer. This fixes the issue with recursive mutex and a constructor/destructor object