### PR TITLE
ble_adapter: Fix LE Secure Connections pairing

### DIFF
--- a/pc_ble_driver_py/ble_adapter.py
+++ b/pc_ble_driver_py/ble_adapter.py
@@ -607,11 +607,12 @@ class BLEAdapter(BLEDriverObserver):
         )
 
         self.driver.ble_gap_authenticate(conn_handle, sec_params)
-        self.evt_sync[conn_handle].wait(evt=BLEEvtID.gap_evt_sec_params_request, timeout=10)
-        # sd_ble_gap_sec_params_reply ... In the central role, sec_params must be set to NULL,
-        # as the parameters have already been provided during a previous call to
-        # sd_ble_gap_authenticate.
-        if not sec_params.lesc:
+        result = self.evt_sync[conn_handle].wait(evt=BLEEvtID.gap_evt_sec_params_request, timeout=10)
+        # LE Secure Connections used only if both sides support it.
+        if not sec_params.lesc or not result["peer_params"].lesc:
+            # sd_ble_gap_sec_params_reply ... In the central role, sec_params must be set to NULL,
+            # as the parameters have already been provided during a previous call to
+            # sd_ble_gap_authenticate.
             sec_params = (
                 None
                 if self.db_conns[conn_handle].role == BLEGapRoles.central


### PR DESCRIPTION
When pc-ble-driver-py was used on central side for initiating LE
Secure Connections pairing against peripheral which does not support
LE SC, pairing timed out because pc-ble-driver-py was waiting for
event gap_evt_lesc_dhkey_request.

Fix is to expect BLEEvtID.gap_evt_lesc_dhkey_request only when both
of the devices support LE Secure Connections.