### PR TITLE
ble_adapter: infinite loop if disconnect occurs after service_discovery is started

### DIFF
--- a/pc_ble_driver_py/ble_adapter.py
+++ b/pc_ble_driver_py/ble_adapter.py
@@ -297,6 +297,11 @@ class BLEAdapter(BLEDriverObserver):
                         self.driver.ble_gattc_prim_srvc_disc(
                             conn_handle, uuid, response["services"][-1].end_handle + 1
                         )
+            else:
+                raise NordicSemiException(
+                    "conn_handle not available. common cause is disconnect after"
+                    "starting service_discovery")
+
 
         for s in vendor_services:
             # Read service handle to obtain full 128-bit UUID.


### PR DESCRIPTION
In the `ble_adapter.py`, after a  `service_discovery`  is started if the target `conn_handle` disconnects the `service_discovery` may end in an infinite loop since in the handling of the disconnect event we remove the `conn_handle` disconnected from the `self.evt_sync` dict.

This seems like a possible way to handle this scenario, but I'm quite new to the codebase, let me know your thought about the issue.
