### PR TITLE
Feature/Adding handling for repeat service/characteristic/descriptor handles

### DIFF
--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -1498,6 +1498,11 @@ class BLEDescriptor(object):
     @classmethod
     def from_c(cls, gattc_desc):
         return cls(uuid=BLEUUID.from_c(gattc_desc.uuid), handle=gattc_desc.handle)
+    
+    def __eq__(self, other):
+        if isinstance(other, BLEDescriptor):
+            return self.uuid == other.uuid
+        return self.uuid == other
 
     def __str__(self):
         return "Descriptor uuid({0.uuid}) handle({0.handle})".format(self)
@@ -1540,6 +1545,11 @@ class BLECharacteristic(object):
             handle_decl=gattc_char.handle_decl,
             handle_value=gattc_char.handle_value,
         )
+    
+    def __eq__(self, other):
+        if isinstance(other, BLECharacteristic):
+            return self.uuid == other.uuid
+        return self.uuid == other
 
     def __repr__(self):
         return "<BLECharacteristic obj>"
@@ -1571,6 +1581,11 @@ class BLEService(object):
         self.chars.append(char)
         if len(self.chars) > 1:
             self.chars[-2].end_handle = char.handle_decl - 1
+    
+    def __eq__(self, other):
+        if isinstance(other, BLEService):
+            return self.uuid == other.uuid
+        return self.uuid == other
 
     def __str__(self):
         return "Service uuid({0.uuid}) start handle({0.start_handle}) end handle({0.end_handle})".format(


### PR DESCRIPTION
After enabling your base UUID, instead of performing a service discovery to discover all services, this update allows you to specify a search for a specific UUID without adding repeat handles. 
Originally, this was already a feature, but would crash if you attempted to add additional service handles because it would repeat the search for the first service. This will check if the service, characteristic, or descriptor that was found already exists. If so, adding the handle is ignored. This allows us to perform a service discovery in an on-need basis.
Edits to ble_driver are to allow comparisons to existing BLEService, BLECharacteristic, BLEDescriptor classes by comparing their UUIDs.