### PR TITLE
Change ble_driver queue.Queue to queue.SimpleQueue

### DIFF
--- a/pc_ble_driver_py/__init__.py
+++ b/pc_ble_driver_py/__init__.py
@@ -38,4 +38,4 @@
 Package marker file.
 """
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"

--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -1898,9 +1898,9 @@ class BLEDriver(object):
         self.rpc_log_severity_filter(log_severity_level_enum)
         self._keyset = self.init_keyset()
 
-        self.log_queue = queue.Queue()
-        self.status_queue = queue.Queue()
-        self.ble_event_queue = queue.Queue()
+        self.log_queue = queue.SimpleQueue()
+        self.status_queue = queue.SimpleQueue()
+        self.ble_event_queue = queue.SimpleQueue()
 
     def init_keyset(self):
         keyset = driver.ble_gap_sec_keyset_t()


### PR DESCRIPTION
Queue.put() is not reentrant. That leads to race
conditions, especially on resource constrained
systems. In this lib this leads to Gatt Attributes not being discovered properly.
SimpleQueue.put() is reentrant and solves those problems.