### PR TITLE
update setup.py for python 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,10 +100,11 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     keywords="nordic nrf51 nrf52 ble bluetooth softdevice serialization bindings pc-ble-driver pc-ble-driver-py "
     "pc_ble_driver pc_ble_driver_py",
-    python_requires=">=3.7, <3.11",
+    python_requires=">=3.7, <3.12",
     install_requires=requirements,
     packages=packages,
     package_data={


### PR DESCRIPTION
I tested generating a wheel for Python 3.11 and it worked.
It seems that the requirements in the setup.py file for this version of Python are too strict. 
I propose removing the restriction for Python 3.11