### PR TITLE
changing log level to debug for driver:ble_driver.py:1043

### DIFF
--- a/pc_ble_driver_py/ble_driver.py
+++ b/pc_ble_driver_py/ble_driver.py
@@ -1040,7 +1040,7 @@ class BLEAdvData(object):
             try:
                 ad_len = ad_list[index]
                 if ad_len == 0:
-                    logger.info(f"ad_len is zero, discarding rest of ad_list")
+                    logger.debug(f"ad_len is zero, discarding rest of ad_list")
                     return ble_adv_data
 
                 ad_type = ad_list[index + 1]


### PR DESCRIPTION
As following log at info level is flooding the terminal.

driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list
INFO     pc_ble_driver_py.ble_driver:ble_driver.py:1043 ad_len is zero, discarding rest of ad_list